### PR TITLE
Fix mdox-gen-exec issues with --help commands

### DIFF
--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -20,7 +20,7 @@ const (
 	infoStringKeyLang     = "mdox-gen-lang"
 	infoStringKeyType     = "mdox-gen-type"
 	infoStringKeyExec     = "mdox-gen-exec"
-	infoStringKeyExitCode = "expect-exit-code"
+	infoStringKeyExitCode = "mdox-expect-exit-code"
 )
 
 type genCodeBlockTransformer struct{}
@@ -40,12 +40,19 @@ func (t *genCodeBlockTransformer) TransformCodeBlock(ctx mdformatter.SourceConte
 	}
 	infoStringAttr := map[string]string{}
 	for i, field := range infoFiels {
-		if val := strings.Split(field, "="); val[0] == infoStringKeyLang || val[0] == infoStringKeyType || val[0] == infoStringKeyExec || val[0] == infoStringKeyExitCode {
-			if i == 0 {
-				return nil, errors.Errorf("missing language info in fenced code block. Got info string %q", string(infoString))
-			}
+		val := strings.Split(field, "=")
+		if i == 0 && len(val) == 2 {
+			return nil, errors.Errorf("missing language info in fenced code block. Got info string %q", string(infoString))
+		}
+		switch val[0] {
+		case infoStringKeyExec, infoStringKeyExitCode:
 			if len(val) != 2 {
-				return nil, errors.Errorf("got %q without variable. Expected format is e.g ```yaml %q=<value> %q=<value2> %q=<value2>. Got info string %q", val[0], infoStringKeyLang, infoStringKeyExitCode, infoStringKeyType, string(infoString))
+				return nil, errors.Errorf("got %q without variable. Expected format is e.g ```yaml %q=<value2> %q=<value2>. Got info string %q", val[0], infoStringKeyExitCode, infoStringKeyExec, string(infoString))
+			}
+			infoStringAttr[val[0]] = val[1]
+		case infoStringKeyLang, infoStringKeyType:
+			if len(val) != 2 {
+				return nil, errors.Errorf("got %q without variable. Expected format is e.g ```yaml %q=<value2> %q=<value2>. Got info string %q", val[0], infoStringKeyLang, infoStringKeyType, string(infoString))
 			}
 			infoStringAttr[val[0]] = val[1]
 		}

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -31,6 +31,6 @@ test output2
 newline
 ```
 
-```bash expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 test output3
 ```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -30,3 +30,7 @@ The configuration format is the following:
 test output2
 newline
 ```
+
+```bash expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+test output3
+```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -34,3 +34,7 @@ alertmanagers:
 - http_config:
   api_version: v1
 ```
+
+```bash expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+abc
+```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -35,6 +35,6 @@ alertmanagers:
   api_version: v1
 ```
 
-```bash expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 abc
 ```

--- a/pkg/mdformatter/mdgen/testdata/out3.sh
+++ b/pkg/mdformatter/mdgen/testdata/out3.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "test output3"
+exit 2


### PR DESCRIPTION
This PR fixes the issue where commands with non 0 exit codes (usually `--help` commands) fail to format. Fixes #10 
Before this fix, the markdown below results in an error,
```
```bash mdox-gen-exec="go --help"
.
.
.
error:  first formatting phase for /Users/saswatamukherjee/web/mdox/test.md: run go --help: exit status 2
``` 
A workaround is using something like `mdox-gen-exec="sh -c 'go --help || exit 0'"` but this is not preferable. 
With this fix, a flag can be passed to allow non zero exit codes to format successfully, like below, 
```
```bash mdox-nonzero-exit-code mdox-gen-exec="go --help"
Go is a tool for managing Go source code.

Usage:

	go <command> [arguments]
...
```
This would also be suitable in case an error code block example needs to be generated.