### PR TITLE
Add mdox-gen-file

### DIFF
--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -159,7 +159,7 @@ func (t *genCodeBlockTransformer) TransformCodeBlock(ctx mdformatter.SourceConte
 			line++
 		}
 		if err := scanner.Err(); err != nil {
-			return nil, errors.Errorf("scanner couldn't read: %v", err)
+			return nil, errors.Wrap(err, "scanner read")
 		}
 		return text, nil
 	}

--- a/pkg/mdformatter/mdgen/mdgen_test.go
+++ b/pkg/mdformatter/mdgen/mdgen_test.go
@@ -8,38 +8,10 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/bwplotka/mdox/pkg/mdformatter"
 	"github.com/efficientgo/tools/pkg/testutil"
-)
-
-const (
-	testDocWithCode = `package test
-
-	import (
-		"bytes"
-		"fmt"
-		"strings"
-		"unsafe"
-	
-		"github.com/sergi/go-diff/diffmatchpatch"
-	)
-	
-	type Diff struct {
-		diffs    []diffmatchpatch.Diff
-		aFn, bFn string
-	}
-	
-	func yoloString(b []byte) string {
-		return *((*string)(unsafe.Pointer(&b)))
-	}
-	
-	func CompareBytes(a []byte, aFn string, b []byte, bFn string) Diff {
-		return Compare(yoloString(a), aFn, yoloString(b), bFn)
-	}	
-	`
 )
 
 func TestFormat_FormatSingle_CodeBlockTransformer(t *testing.T) {
@@ -65,33 +37,6 @@ func TestFormat_FormatSingle_CodeBlockTransformer(t *testing.T) {
 
 		buf := bytes.Buffer{}
 		testutil.Ok(t, f.Format(file2, &buf))
-		testutil.Equals(t, string(exp), buf.String())
-	})
-}
-
-func TestFormat_FormatFileGen_CodeBlockTransformer(t *testing.T) {
-	f := mdformatter.New(context.Background(), mdformatter.WithCodeBlockTransformer(NewCodeBlockTransformer()))
-	tmpDir, err := ioutil.TempDir("", "test-filegen")
-	testutil.Ok(t, err)
-	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
-
-	testDocWithFileGen := "```go mdox-gen-file=" + filepath.Join(tmpDir, "test.go") + " mdox-gen-lines=17:19\n```"
-	testDocWithFileGenFormatted := "```go mdox-gen-file=" + filepath.Join(tmpDir, "test.go") + " mdox-gen-lines=17:19\n\tfunc yoloString(b []byte) string {\n\t\treturn *((*string)(unsafe.Pointer(&b)))\n\t}\n```\n"
-
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "doc.md"), []byte(testDocWithFileGen), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "doc_formatted.md"), []byte(testDocWithFileGenFormatted), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "test.go"), []byte(testDocWithCode), os.ModePerm))
-
-	exp, err := ioutil.ReadFile(filepath.Join(tmpDir, "doc_formatted.md"))
-	testutil.Ok(t, err)
-
-	t.Run("Codegen should match by taking lines from file.", func(t *testing.T) {
-		file, err := os.OpenFile(filepath.Join(tmpDir, "doc.md"), os.O_RDONLY, 0)
-		testutil.Ok(t, err)
-		defer file.Close()
-
-		buf := bytes.Buffer{}
-		testutil.Ok(t, f.Format(file, &buf))
 		testutil.Equals(t, string(exp), buf.String())
 	})
 }

--- a/pkg/mdformatter/mdgen/mdgen_test.go
+++ b/pkg/mdformatter/mdgen/mdgen_test.go
@@ -8,10 +8,38 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bwplotka/mdox/pkg/mdformatter"
 	"github.com/efficientgo/tools/pkg/testutil"
+)
+
+const (
+	testDocWithCode = `package test
+
+	import (
+		"bytes"
+		"fmt"
+		"strings"
+		"unsafe"
+	
+		"github.com/sergi/go-diff/diffmatchpatch"
+	)
+	
+	type Diff struct {
+		diffs    []diffmatchpatch.Diff
+		aFn, bFn string
+	}
+	
+	func yoloString(b []byte) string {
+		return *((*string)(unsafe.Pointer(&b)))
+	}
+	
+	func CompareBytes(a []byte, aFn string, b []byte, bFn string) Diff {
+		return Compare(yoloString(a), aFn, yoloString(b), bFn)
+	}	
+	`
 )
 
 func TestFormat_FormatSingle_CodeBlockTransformer(t *testing.T) {
@@ -37,6 +65,33 @@ func TestFormat_FormatSingle_CodeBlockTransformer(t *testing.T) {
 
 		buf := bytes.Buffer{}
 		testutil.Ok(t, f.Format(file2, &buf))
+		testutil.Equals(t, string(exp), buf.String())
+	})
+}
+
+func TestFormat_FormatFileGen_CodeBlockTransformer(t *testing.T) {
+	f := mdformatter.New(context.Background(), mdformatter.WithCodeBlockTransformer(NewCodeBlockTransformer()))
+	tmpDir, err := ioutil.TempDir("", "test-filegen")
+	testutil.Ok(t, err)
+	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
+
+	testDocWithFileGen := "```go mdox-gen-file=" + filepath.Join(tmpDir, "test.go") + " mdox-gen-lines=17:19\n```"
+	testDocWithFileGenFormatted := "```go mdox-gen-file=" + filepath.Join(tmpDir, "test.go") + " mdox-gen-lines=17:19\n\tfunc yoloString(b []byte) string {\n\t\treturn *((*string)(unsafe.Pointer(&b)))\n\t}\n```\n"
+
+	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "doc.md"), []byte(testDocWithFileGen), os.ModePerm))
+	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "doc_formatted.md"), []byte(testDocWithFileGenFormatted), os.ModePerm))
+	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "test.go"), []byte(testDocWithCode), os.ModePerm))
+
+	exp, err := ioutil.ReadFile(filepath.Join(tmpDir, "doc_formatted.md"))
+	testutil.Ok(t, err)
+
+	t.Run("Codegen should match by taking lines from file.", func(t *testing.T) {
+		file, err := os.OpenFile(filepath.Join(tmpDir, "doc.md"), os.O_RDONLY, 0)
+		testutil.Ok(t, err)
+		defer file.Close()
+
+		buf := bytes.Buffer{}
+		testutil.Ok(t, f.Format(file, &buf))
 		testutil.Equals(t, string(exp), buf.String())
 	})
 }

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -34,3 +34,16 @@ newline
 ```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 test output3
 ```
+
+```bash mdox-gen-file="./testdata/out3.sh" mdox-gen-lines=2:4
+
+echo "test output3"
+exit 2
+```
+
+```bash mdox-gen-file="./testdata/out2.sh"
+#!/usr/bin/env bash
+
+echo "test output2"
+echo "newline"
+```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -38,3 +38,9 @@ alertmanagers:
 ```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 abc
 ```
+
+```bash mdox-gen-file="./testdata/out3.sh" mdox-gen-lines=2:4
+```
+
+```bash mdox-gen-file="./testdata/out2.sh"
+```


### PR DESCRIPTION
This PR adds an `mdox-gen-file` option which allows fetching code from local files into documentation like below. Addresses #18 
```
```go mdox-gen-file="main.go" mdox-gen-lines=47-56

```
This results in the following when formatted,
```
```go mdox-gen-file="main.go" mdox-gen-lines=47-56
	switch logFormat {
	case logFormatJson:
		return level.NewFilter(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), lvl)
	case logFormatLogfmt:
		return level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), lvl)
	case logFormatCLILog:
		fallthrough
	default:
		return level.NewFilter(clilog.New(log.NewSyncWriter(os.Stderr)), lvl)
	}
. . .
```
If no line numbers are given like below, entire file is brought in by default (useful for blogs),
```
```go mdox-gen-file="main.go" mdox-gen-lines=47-56
```
