### PR TITLE
Add `sed` testcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ For example this Readme contains `mdox --help` which is has to be auto generated
 ...
 ```
 
+This also enables auto updating snippets of code in code blocks using tools like `sed`. For example, below code block directive will auto update and insert lines 3 to 6 from main.go into code block.
+
+```markdown
+```go mdox-gen-exec="go mdox-gen-exec="sed -n '3,6p' main.go"
+...
+```
+
 You can disable this feature by specifying `--code.disable-directives`
 
 ### Installing

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -34,3 +34,9 @@ newline
 ```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 test output3
 ```
+
+```bash mdox-gen-exec="sed -n '1,3p' ./testdata/out3.sh"
+#!/usr/bin/env bash
+
+echo "test output3"
+```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -38,3 +38,6 @@ alertmanagers:
 ```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
 abc
 ```
+
+```bash mdox-gen-exec="sed -n '1,3p' ./testdata/out3.sh"
+```


### PR DESCRIPTION
This PR adds in usage of `sed` with `mdox-gen-exec` as a testcase and mentions this in README as it's a common use case, as discussed in #19. 🙂
Resolves #18.