### PR TITLE
Fix same link in different file error

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -31,6 +31,10 @@ var (
 	IDNotFoundErr   = LookupError(errors.New("file exists, but does not have such id"))
 )
 
+const (
+	originalURLKey = "originalURLKey"
+)
+
 type chain struct {
 	chain []mdformatter.LinkTransformer
 }
@@ -153,17 +157,17 @@ func NewValidator(logger log.Logger, except *regexp.Regexp, anchorDir string) (m
 	v.c.OnRequest(func(request *colly.Request) {
 		v.rMu.Lock()
 		defer v.rMu.Unlock()
-		request.Ctx.Put("originalURL", request.URL.String())
+		request.Ctx.Put(originalURLKey, request.URL.String())
 	})
 	v.c.OnScraped(func(response *colly.Response) {
 		v.rMu.Lock()
 		defer v.rMu.Unlock()
-		v.remoteLinks[response.Ctx.Get("originalURL")] = nil
+		v.remoteLinks[response.Ctx.Get(originalURLKey)] = nil
 	})
 	v.c.OnError(func(response *colly.Response, err error) {
 		v.rMu.Lock()
 		defer v.rMu.Unlock()
-		v.remoteLinks[response.Ctx.Get("originalURL")] = errors.Wrapf(err, "%q not accessible; status code %v", response.Request.URL.String(), response.StatusCode)
+		v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(err, "%q not accessible; status code %v", response.Request.URL.String(), response.StatusCode)
 	})
 	return v, nil
 }

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -146,6 +146,23 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 	})
 
+	t.Run("check valid but same link in diff files", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
+		testFile2 := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link2.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, ioutil.WriteFile(testFile2, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile, testFile2})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile, testFile2}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+		))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+	})
+
 	t.Run("check valid local links", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links.md")
 		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# yolo


### PR DESCRIPTION
Currently, if there are same links but in different files (come under same file glob passed to mdox) like [here](https://github.com/thanos-io/thanos/blame/main/docs/contributing/mentorship.md#L26) and [here](https://github.com/thanos-io/thanos/blame/main/docs/contributing/community.md#L36),  mdox throws the error below,
```
remote link https://slack.cncf.io/: URL already visited
```
Even though the link is valid.
This PR fixes this and adds a test case for the same. 