### PR TITLE
Change to `mdox-exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Just run `mdox fmt` and pass markdown files (or glob matching those).
 
 For example this README is formatted by the CI on every PR using [`mdox fmt -l *.md` command](https://github.com/bwplotka/mdox/blob/9e183714070f464b1ef089da3df8048aff1abeda/Makefile#L59).
 
-```bash mdox-gen-exec="mdox fmt --help"
+```bash mdox-exec="mdox fmt --help"
 usage: mdox fmt [<flags>] <files>...
 
 Formats in-place given markdown files uniformly following GFM (Github Flavored
@@ -39,7 +39,7 @@ Flags:
                                  directives prefixed with 'mdox-gen' to
                                  autogenerate code snippets. For example:
                                  
-                                   ```<lang> mdox-gen-exec="<executable + arguments>"
+                                   ```<lang> mdox-exec="<executable + arguments>"
                                  
                                  This directive runs executable with arguments
                                  and put its stderr and stdout output inside
@@ -64,19 +64,19 @@ Args:
 
 ### Code Generation
 
-It's not uncommon that documentation is explaining code or configuration snippets. One of the challenges of such documentation is keeping it up to date. This is where `mdox` code block directives comes handy! To ensure mdox will auto update code snippet add `mdox-gen-exec="<whatever command you want take output from>"` after language directive on code block.
+It's not uncommon that documentation is explaining code or configuration snippets. One of the challenges of such documentation is keeping it up to date. This is where `mdox` code block directives comes handy! To ensure mdox will auto update code snippet add `mdox-exec="<whatever command you want take output from>"` after language directive on code block.
 
 For example this Readme contains `mdox --help` which is has to be auto generated on every PR:
 
 ```markdown
-``` bash mdox-gen-exec="mdox fmt --help"
+``` bash mdox-exec="mdox fmt --help"
 ...
 ```
 
 This also enables auto updating snippets of code in code blocks using tools like `sed`. For example, below code block directive will auto update and insert lines 3 to 6 from main.go into code block.
 
 ```markdown
-```go mdox-gen-exec="go mdox-gen-exec="sed -n '3,6p' main.go"
+```go mdox-exec="sed -n '3,6p' main.go"
 ...
 ```
 

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func registerFmt(_ context.Context, app *extkingpin.App) {
 	checkOnly := cmd.Flag("check", "If true, fmt will not modify the given files, instead it will fail if files needs formatting").Bool()
 
 	disableGenCodeBlocksDirectives := cmd.Flag("code.disable-directives", `If false, fmt will parse custom fenced code directives prefixed with 'mdox-gen' to autogenerate code snippets. For example:
-	`+"```"+`<lang> mdox-gen-exec="<executable + arguments>"
+	`+"```"+`<lang> mdox-exec="<executable + arguments>"
 This directive runs executable with arguments and put its stderr and stdout output inside code block content, replacing existing one.`).Bool()
 	anchorDir := cmd.Flag("anchor-dir", "Anchor directory for all transformers. PWD is used if flag is not specified.").ExistingDir()
 	linksLocalizeForAddress := cmd.Flag("links.localize.address-regex", "If specified, all HTTP(s) links that target a domain and path matching given regexp will be transformed to relative to anchor dir path (if exists)."+

--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -19,7 +19,7 @@ import (
 const (
 	infoStringKeyLang     = "mdox-gen-lang"
 	infoStringKeyType     = "mdox-gen-type"
-	infoStringKeyExec     = "mdox-gen-exec"
+	infoStringKeyExec     = "mdox-exec"
 	infoStringKeyExitCode = "mdox-expect-exit-code"
 )
 

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -1,6 +1,6 @@
 # Quick Tutorial
 
-```bash mdox-gen-exec="bash ./testdata/out.sh"
+```bash mdox-exec="bash ./testdata/out.sh"
 test output
 ```
 
@@ -26,16 +26,16 @@ The `--alertmanagers.config` and `--alertmanagers.config-file` flags allow speci
 
 The configuration format is the following:
 
-```yaml mdox-gen-exec="bash ./testdata/out2.sh"
+```yaml mdox-exec="bash ./testdata/out2.sh"
 test output2
 newline
 ```
 
-```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+```bash mdox-expect-exit-code=2 mdox-exec="bash ./testdata/out3.sh"
 test output3
 ```
 
-```bash mdox-gen-exec="sed -n '1,3p' ./testdata/out3.sh"
+```bash mdox-exec="sed -n '1,3p' ./testdata/out3.sh"
 #!/usr/bin/env bash
 
 echo "test output3"

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -1,7 +1,7 @@
 Quick Tutorial
 ==============
 
-```bash mdox-gen-exec="bash ./testdata/out.sh"
+```bash mdox-exec="bash ./testdata/out.sh"
 a
 adf
 ```
@@ -29,15 +29,15 @@ The `--alertmanagers.config` and `--alertmanagers.config-file` flags allow speci
 
 The configuration format is the following:
 
-```yaml mdox-gen-exec="bash ./testdata/out2.sh"
+```yaml mdox-exec="bash ./testdata/out2.sh"
 alertmanagers:
 - http_config:
   api_version: v1
 ```
 
-```bash mdox-expect-exit-code=2 mdox-gen-exec="bash ./testdata/out3.sh"
+```bash mdox-expect-exit-code=2 mdox-exec="bash ./testdata/out3.sh"
 abc
 ```
 
-```bash mdox-gen-exec="sed -n '1,3p' ./testdata/out3.sh"
+```bash mdox-exec="sed -n '1,3p' ./testdata/out3.sh"
 ```


### PR DESCRIPTION
Changing the code generation directive from `mdox-gen-exec` to `mdox-exec` as discussed [here](https://github.com/bwplotka/mdox/pull/25#discussion_r631851611). 🙂