### PR TITLE
Fix `clilog` file names for link errors

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -203,11 +203,11 @@ func (v *validator) Close(ctx mdformatter.SourceContext) error {
 	merr := merrors.New()
 	base, err := os.Getwd()
 	if err != nil {
-		merr.Add(errors.Wrapf(err, "could not resolve working dir"))
+		return errors.Wrap(err, "resolve working dir")
 	}
 	path, err := filepath.Rel(base, ctx.Filepath)
 	if err != nil {
-		merr.Add(errors.Wrapf(err, "could not find relative path"))
+		return errors.Wrap(err, "find relative path")
 	}
 
 	for _, k := range keys {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -201,14 +201,23 @@ func (v *validator) Close(ctx mdformatter.SourceContext) error {
 	})
 
 	merr := merrors.New()
+	base, err := os.Getwd()
+	if err != nil {
+		merr.Add(errors.Wrapf(err, "could not resolve working dir"))
+	}
+	path, err := filepath.Rel(base, ctx.Filepath)
+	if err != nil {
+		merr.Add(errors.Wrapf(err, "could not find relative path"))
+	}
+
 	for _, k := range keys {
 		f := v.destFutures[k]
 		if err := f.resultFn(); err != nil {
 			if f.cases == 1 {
-				merr.Add(err)
+				merr.Add(errors.Wrapf(err, "%v", path))
 				continue
 			}
-			merr.Add(errors.Wrapf(err, "(%v occurrences)", f.cases))
+			merr.Add(errors.Wrapf(err, "%v (%v occurrences)", path, f.cases))
 		}
 	}
 	return merr.Err()


### PR DESCRIPTION
Fixes #28. 
Currently, link checking errors are handled by [merrors](https://github.com/efficientgo/tools/tree/main/core/pkg/merrors) and are pretty printed when `log.format` is set to `clilog`(this is set to default since it is human-readable). However the filenames of the relevant errors are not shown in `clilog` even though it is [wrapped](https://github.com/bwplotka/mdox/blob/main/pkg/mdformatter/mdformatter.go#L269). This is due to the [`PrettyPrint`](https://github.com/efficientgo/tools/blob/main/core/pkg/merrors/errors.go#L186) function which in turn calls [`errors.As()`](https://github.com/efficientgo/tools/blob/main/core/pkg/merrors/errors.go#L168). According to [docs](https://golang.org/pkg/errors/#As) the passed in error is repeatedly unwrapped which causes us to lose the filename. There is also no way to pass in the filename without losing the pretty print functionality,

This PR fixes this by wrapping each error with the relative path of the file it originates from thus allowing us to have logs like below,
```
error: 31 errors:
5 errors:
                getting-started.md: link /scripts/quickstart.sh, normalized to: /Users/saswatamukherjee/web/thanos/docs/scripts/quickstart.sh: file not found
                getting-started.md: link /examples/dashboards/dashboards.md, normalized to: /Users/saswatamukherjee/web/thanos/docs/examples/dashboards/dashboards.md: file not found
                getting-started.md: link /examples/alerts/alerts.md, normalized to: /Users/saswatamukherjee/web/thanos/docs/examples/alerts/alerts.md: file not found
                getting-started.md: link /MAINTAINERS.md, normalized to: /Users/saswatamukherjee/web/thanos/docs/MAINTAINERS.md: file not found
                getting-started.md: link /CONTRIBUTING.md, normalized to: /Users/saswatamukherjee/web/thanos/docs/CONTRIBUTING.md: file not found
```