### PR TITLE
Add `links.validate.config` flag

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -55,4 +55,5 @@ jobs:
       - name: Run unit tests.
         env:
           GOBIN: /tmp/.bin
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make test

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Flags:
       --links.validate.without-address-regex=^$  
                                  If specified, all links will be validated,
                                  except those matching the given target address.
+      --links.validate.without-github-links=""  
+                                 If specified, all links will be validated,
+                                 except the GitHub links for PRs and issues of
+                                 the given repo.
 
 Args:
   <files>  Markdown file(s) to process.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ Flags:
                                  exists).Absolute path links will be converted
                                  to relative links to anchor dir as well.
   -l, --links.validate           If true, all links will be validated
-      --links.validate.without-address-regex=^$  
-                                 If specified, all links will be validated,
-                                 except those matching the given target address.
-      --links.validate.config=""  
+      --links.validate.config-file=<file-path>  
                                  Path to YAML file for skipping link check, with
                                  spec defined in
-                                 github.com/bwplotka/mdox/pkg/linktranformer.Config
+                                 github.com/bwplotka/mdox/pkg/linktransformer.Config
+      --links.validate.config=<content>  
+                                 Alternative to 'links.validate.config-file'
+                                 flag (mutually exclusive). Content of YAML file
+                                 for skipping link check, with spec defined in
+                                 github.com/bwplotka/mdox/pkg/linktransformer.Config
 
 Args:
   <files>  Markdown file(s) to process.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Flags:
       --links.validate.without-address-regex=^$  
                                  If specified, all links will be validated,
                                  except those matching the given target address.
-      --links.validate.without-github-links=""  
-                                 If specified, all links will be validated,
-                                 except the GitHub links for PRs and issues of
-                                 the given repo.
+      --links.validate.config=""  
+                                 Path to YAML file for skipping link check, with
+                                 spec defined in
+                                 github.com/bwplotka/mdox/pkg/linktranformer.Config
 
 Args:
   <files>  Markdown file(s) to process.

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
-	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", false)
+	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", false, true)
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateExceptDomains := cmd.Flag("links.validate.without-address-regex", "If specified, all links will be validated, except those matching the given target address.").Default(`^$`).Regexp()
+	linksSkipGitHub := cmd.Flag("links.validate.without-github-links", "If specified, all links will be validated, except the GitHub links for PRs and issues of the given repo.").Default("").String()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option
@@ -151,7 +152,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 
 		var linkTr []mdformatter.LinkTransformer
 		if *linksValidateEnabled {
-			v, err := linktransformer.NewValidator(logger, *linksValidateExceptDomains, anchorDir)
+			v, err := linktransformer.NewValidator(logger, *linksValidateExceptDomains, *linksSkipGitHub, anchorDir)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/bwplotka/mdox/pkg/clilog"
+	"github.com/bwplotka/mdox/pkg/extflag"
 	"github.com/bwplotka/mdox/pkg/extkingpin"
 	"github.com/bwplotka/mdox/pkg/mdformatter"
 	"github.com/bwplotka/mdox/pkg/mdformatter/linktransformer"
@@ -126,8 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
-	linksValidateExceptDomains := cmd.Flag("links.validate.without-address-regex", "If specified, all links will be validated, except those matching the given target address.").Default(`^$`).Regexp()
-	linksValidateConfig := cmd.Flag("links.validate.config", "Path to YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktranformer.Config").Default("").String()
+	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", false)
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option
@@ -152,7 +152,11 @@ This directive runs executable with arguments and put its stderr and stdout outp
 
 		var linkTr []mdformatter.LinkTransformer
 		if *linksValidateEnabled {
-			v, err := linktransformer.NewValidator(logger, *linksValidateExceptDomains, *linksValidateConfig, anchorDir)
+			validateConfigContent, err := linksValidateConfig.Content()
+			if err != nil {
+				return err
+			}
+			v, err := linktransformer.NewValidator(logger, validateConfigContent, anchorDir)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateExceptDomains := cmd.Flag("links.validate.without-address-regex", "If specified, all links will be validated, except those matching the given target address.").Default(`^$`).Regexp()
-	linksSkipGitHub := cmd.Flag("links.validate.without-github-links", "If specified, all links will be validated, except the GitHub links for PRs and issues of the given repo.").Default("").String()
+	linksValidateConfig := cmd.Flag("links.validate.config", "Path to YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktranformer.Config").Default("").String()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option
@@ -152,7 +152,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 
 		var linkTr []mdformatter.LinkTransformer
 		if *linksValidateEnabled {
-			v, err := linktransformer.NewValidator(logger, *linksValidateExceptDomains, *linksSkipGitHub, anchorDir)
+			v, err := linktransformer.NewValidator(logger, *linksValidateExceptDomains, *linksValidateConfig, anchorDir)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
-	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", false, true)
+	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", extflag.WithEnvSubstitution(true))
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
-	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", extflag.WithEnvSubstitution(true))
+	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", extflag.WithEnvSubstitution())
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -29,12 +28,15 @@ type PathOrContent struct {
 	content *string
 }
 
+// Option is a functional option type for PathOrContent objects.
+type Option func(*PathOrContent)
+
 type FlagClause interface {
 	Flag(name, help string) *kingpin.FlagClause
 }
 
 // RegisterPathOrContent registers PathOrContent flag in kingpinCmdClause.
-func RegisterPathOrContent(cmd FlagClause, flagName string, help string, required bool, envSubstitution bool) *PathOrContent {
+func RegisterPathOrContent(cmd FlagClause, flagName string, help string, opts ...Option) *PathOrContent {
 	fileFlagName := fmt.Sprintf("%s-file", flagName)
 	contentFlagName := flagName
 
@@ -44,13 +46,17 @@ func RegisterPathOrContent(cmd FlagClause, flagName string, help string, require
 	contentHelp := fmt.Sprintf("Alternative to '%s' flag (mutually exclusive). Content of %s", fileFlagName, help)
 	contentFlag := cmd.Flag(contentFlagName, contentHelp).PlaceHolder("<content>").String()
 
-	return &PathOrContent{
+	p := &PathOrContent{
 		flagName:        flagName,
-		required:        required,
 		path:            fileFlag,
 		content:         contentFlag,
-		envSubstitution: envSubstitution,
+		required:        false,
+		envSubstitution: false,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // Content returns the content of the file when given or directly the content that has been passed to the flag.
@@ -80,24 +86,45 @@ func (p *PathOrContent) Content() ([]byte, error) {
 		return nil, errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, p.flagName)
 	}
 	if p.envSubstitution {
-		content = substituteEnvVars(string(content))
+		replace, err := expandEnv(content)
+		if err != nil {
+			return nil, err
+		}
+		content = replace
 	}
 	return content, nil
 }
 
-// substituteEnvVars returns content of YAML file with substituted environment variables.
-// Will be substituted with empty string if env var isn't set.
-// Follows K8s convention, i.e $(...), as mentioned here https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/.
-func substituteEnvVars(content string) []byte {
-	var replaceWithEnv []string
-	// Match env variable syntax.
-	envVarName := regexp.MustCompile(`\$\((?P<var>[a-zA-Z_]+[a-zA-Z0-9_]*)\)`)
-	loc := envVarName.FindAllStringSubmatchIndex(content, -1)
-	for i := range loc {
-		// Add pair to be replaced.
-		replaceWithEnv = append(replaceWithEnv, content[loc[i][0]:loc[i][1]], os.Getenv(content[loc[i][2]:loc[i][3]]))
+// WithRequired allows you to override default required option.
+func WithRequired(r bool) Option {
+	return func(p *PathOrContent) {
+		p.required = r
 	}
-	replacer := strings.NewReplacer(replaceWithEnv...)
-	contentWithEnv := replacer.Replace(content)
-	return []byte(contentWithEnv)
+}
+
+// WithRequired allows you to override default envSubstitution option.
+func WithEnvSubstitution(e bool) Option {
+	return func(p *PathOrContent) {
+		p.envSubstitution = e
+	}
+}
+
+// expandEnv returns content of YAML file with substituted environment variables.
+// Follows K8s convention, i.e $(...), as mentioned here https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/.
+func expandEnv(b []byte) (r []byte, err error) {
+	var envRe = regexp.MustCompile(`\$\(([a-zA-Z_0-9]+)\)`)
+	r = envRe.ReplaceAllFunc(b, func(n []byte) []byte {
+		if err != nil {
+			return nil
+		}
+		n = n[2 : len(n)-1]
+
+		v, ok := os.LookupEnv(string(n))
+		if !ok {
+			err = errors.Errorf("found reference to unset environment variable %q", n)
+			return nil
+		}
+		return []byte(v)
+	})
+	return r, err
 }

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -96,16 +96,16 @@ func (p *PathOrContent) Content() ([]byte, error) {
 }
 
 // WithRequired allows you to override default required option.
-func WithRequired(r bool) Option {
+func WithRequired() Option {
 	return func(p *PathOrContent) {
-		p.required = r
+		p.required = true
 	}
 }
 
 // WithRequired allows you to override default envSubstitution option.
-func WithEnvSubstitution(e bool) Option {
+func WithEnvSubstitution() Option {
 	return func(p *PathOrContent) {
-		p.envSubstitution = e
+		p.envSubstitution = true
 	}
 }
 

--- a/pkg/extflag/pathorcontent.go
+++ b/pkg/extflag/pathorcontent.go
@@ -1,0 +1,79 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+// Taken from Thanos project.
+//
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+package extflag
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// PathOrContent is a flag type that defines two flags to fetch bytes. Either from file (*-file flag) or content (* flag).
+type PathOrContent struct {
+	flagName string
+
+	required bool
+
+	path    *string
+	content *string
+}
+
+type FlagClause interface {
+	Flag(name, help string) *kingpin.FlagClause
+}
+
+// RegisterPathOrContent registers PathOrContent flag in kingpinCmdClause.
+func RegisterPathOrContent(cmd FlagClause, flagName string, help string, required bool) *PathOrContent {
+	fileFlagName := fmt.Sprintf("%s-file", flagName)
+	contentFlagName := flagName
+
+	fileHelp := fmt.Sprintf("Path to %s", help)
+	fileFlag := cmd.Flag(fileFlagName, fileHelp).PlaceHolder("<file-path>").String()
+
+	contentHelp := fmt.Sprintf("Alternative to '%s' flag (mutually exclusive). Content of %s", fileFlagName, help)
+	contentFlag := cmd.Flag(contentFlagName, contentHelp).PlaceHolder("<content>").String()
+
+	return &PathOrContent{
+		flagName: flagName,
+		required: required,
+		path:     fileFlag,
+		content:  contentFlag,
+	}
+}
+
+// Content returns the content of the file when given or directly the content that has been passed to the flag.
+// It returns an error when:
+// * The file and content flags are both not empty.
+// * The file flag is not empty but the file can't be read.
+// * The content is empty and the flag has been defined as required.
+func (p *PathOrContent) Content() ([]byte, error) {
+	fileFlagName := fmt.Sprintf("%s-file", p.flagName)
+
+	if len(*p.path) > 0 && len(*p.content) > 0 {
+		return nil, errors.Errorf("both %s and %s flags set.", fileFlagName, p.flagName)
+	}
+
+	var content []byte
+	if len(*p.path) > 0 {
+		c, err := ioutil.ReadFile(*p.path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "loading file %s for %s", *p.path, fileFlagName)
+		}
+		content = c
+	} else {
+		content = []byte(*p.content)
+	}
+
+	if len(content) == 0 && p.required {
+		return nil, errors.Errorf("flag %s or %s is required for running this command and content cannot be empty.", fileFlagName, p.flagName)
+	}
+
+	return content, nil
+}

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -1,0 +1,64 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package linktransformer
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Version int
+
+	Validate struct {
+		Validators []Validator `yaml:"validators"`
+	}
+}
+
+type Validator struct {
+	_regex  *regexp.Regexp
+	_maxnum int
+	// Regex for type github is reponame matcher, like `bwplotka\/mdox`.
+	Regex string `yaml:"regex"`
+	// By default type is `roundtrip`. Could be `github`.
+	Type string `yaml:"type"`
+}
+
+func parseConfigFile(configFile string) (Config, error) {
+	if configFile == "" {
+		return Config{}, nil
+	}
+	configFile, err := filepath.Abs(configFile)
+	if err != nil {
+		return Config{}, errors.Wrap(err, "abs")
+	}
+	c, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return Config{}, errors.Wrap(err, "read config file")
+	}
+	return ParseConfig(c)
+}
+
+func ParseConfig(c []byte) (Config, error) {
+	cfg := Config{}
+	dec := yaml.NewDecoder(bytes.NewReader(c))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return Config{}, errors.Wrapf(err, "parsing YAML content %q", string(c))
+	}
+
+	if len(cfg.Validate.Validators) <= 0 {
+		return Config{}, errors.New("No validator provided")
+	}
+
+	for i := range cfg.Validate.Validators {
+		cfg.Validate.Validators[i]._regex = regexp.MustCompile(cfg.Validate.Validators[i].Regex)
+	}
+	return cfg, nil
+}

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -5,34 +5,64 @@ package linktransformer
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
-const roundtrip ValidatorType = "roundtrip"
-
-// const github ValidatorType = "github"
-
 type Config struct {
 	Version int
 
-	Validators []Validator `yaml:"validators"`
+	Validators []ValidatorConfig `yaml:"validators"`
 }
 
-type Validator struct {
-	_regex  *regexp.Regexp
-	_maxNum int
+type ValidatorConfig struct {
 	// Regex for type github is reponame matcher, like `bwplotka\/mdox`.
 	Regex string `yaml:"regex"`
-	// By default type is `roundtrip`. Could be `github`.
+	// By default type is `ignore`. Could be `github` or `roundtrip`.
 	Type ValidatorType `yaml:"type"`
 	// GitHub repo token to avoid getting rate limited.
 	Token string `yaml:"token"`
+
+	ghValidator GitHubValidator
+	rtValidator RoundTripValidator
+	igValidator IgnoreValidator
+}
+
+type RoundTripValidator struct {
+	_regex *regexp.Regexp
+}
+
+type GitHubValidator struct {
+	_regex  *regexp.Regexp
+	_maxNum int
+}
+
+type IgnoreValidator struct {
+	_regex *regexp.Regexp
 }
 
 type ValidatorType string
+
+const (
+	roundtripValidator ValidatorType = "roundtrip"
+	githubValidator    ValidatorType = "github"
+	ignoreValidator    ValidatorType = "ignore"
+)
+
+const (
+	gitHubAPIURL = "https://api.github.com/repos/%v/%v?sort=created&direction=desc&per_page=1"
+)
+
+type GitHubResponse struct {
+	Number int `json:"number"`
+}
 
 func ParseConfig(c []byte) (Config, error) {
 	cfg := Config{}
@@ -46,8 +76,92 @@ func ParseConfig(c []byte) (Config, error) {
 		return Config{}, errors.New("No validator provided")
 	}
 
+	// Evaluate regex for given validators.
 	for i := range cfg.Validators {
-		cfg.Validators[i]._regex = regexp.MustCompile(cfg.Validators[i].Regex)
+		switch cfg.Validators[i].Type {
+		case roundtripValidator:
+			cfg.Validators[i].rtValidator._regex = regexp.MustCompile(cfg.Validators[i].Regex)
+		case githubValidator:
+			regex, maxNum, err := getGitHubRegex(cfg.Validators[i].Regex, cfg.Validators[i].Token)
+			if err != nil {
+				return Config{}, errors.Wrapf(err, "parsing GitHub Regex %v", err)
+			}
+			cfg.Validators[i].ghValidator._regex = regex
+			cfg.Validators[i].ghValidator._maxNum = maxNum
+		case ignoreValidator:
+			cfg.Validators[i].igValidator._regex = regexp.MustCompile(cfg.Validators[i].Regex)
+		default:
+			return Config{}, errors.New("Validator type not supported")
+		}
 	}
 	return cfg, nil
+}
+
+// getGitHubRegex returns GitHub pulls/issues regex from repo name.
+func getGitHubRegex(repoRe string, repoToken string) (*regexp.Regexp, int, error) {
+	// Get reponame from regex.
+	getRepo := regexp.MustCompile(`(?P<org>[A-Za-z0-9_.-]+)\\\/(?P<repo>[A-Za-z0-9_.-]+)`)
+	match := getRepo.FindStringSubmatch(repoRe)
+	if len(match) != 3 {
+		return nil, math.MaxInt64, errors.New("repo name regex not valid")
+	}
+	reponame := match[1] + "/" + match[2]
+
+	var pullNum []GitHubResponse
+	var issueNum []GitHubResponse
+	max := 0
+	// All GitHub API reqs need to have User-Agent: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required.
+	client := &http.Client{}
+
+	// Check latest pull request number.
+	reqPull, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIURL, reponame, "pulls"), nil)
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	reqPull.Header.Set("User-Agent", "mdox")
+
+	// Check latest issue number and return whichever is greater.
+	reqIssue, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIURL, reponame, "issues"), nil)
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	reqIssue.Header.Set("User-Agent", "mdox")
+
+	if repoToken != "" {
+		reqPull.Header.Set("Authorization", "Bearer "+repoToken)
+		reqIssue.Header.Set("Authorization", "Bearer "+repoToken)
+	}
+
+	respPull, err := client.Do(reqPull)
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if respPull.StatusCode != 200 {
+		return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
+	}
+	defer respPull.Body.Close()
+	if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
+		return nil, math.MaxInt64, err
+	}
+
+	respIssue, err := client.Do(reqIssue)
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if respIssue.StatusCode != 200 {
+		return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
+	}
+	defer respIssue.Body.Close()
+	if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {
+		return nil, math.MaxInt64, err
+	}
+
+	if len(pullNum) > 0 {
+		max = pullNum[0].Number
+	}
+	if len(issueNum) > 0 && issueNum[0].Number > max {
+		max = issueNum[0].Number
+	}
+
+	return regexp.MustCompile(`(^http[s]?:\/\/)(www\.)?(github\.com\/)(` + repoRe + `)(\/pull\/|\/issues\/)`), max, nil
 }

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -28,6 +28,8 @@ type Validator struct {
 	Regex string `yaml:"regex"`
 	// By default type is `roundtrip`. Could be `github`.
 	Type ValidatorType `yaml:"type"`
+	// GitHub repo token to avoid getting rate limited.
+	Token string `yaml:"token"`
 }
 
 type ValidatorType string

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -11,6 +11,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const roundtrip ValidatorType = "roundtrip"
+
+// const github ValidatorType = "github"
+
 type Config struct {
 	Version int
 
@@ -23,13 +27,12 @@ type Validator struct {
 	// Regex for type github is reponame matcher, like `bwplotka\/mdox`.
 	Regex string `yaml:"regex"`
 	// By default type is `roundtrip`. Could be `github`.
-	Type string `yaml:"type"`
+	Type ValidatorType `yaml:"type"`
 }
 
+type ValidatorType string
+
 func ParseConfig(c []byte) (Config, error) {
-	if string(c) == "" {
-		return Config{}, nil
-	}
 	cfg := Config{}
 	dec := yaml.NewDecoder(bytes.NewReader(c))
 	dec.KnownFields(true)

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -5,8 +5,6 @@ package linktransformer
 
 import (
 	"bytes"
-	"io/ioutil"
-	"path/filepath"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -16,36 +14,22 @@ import (
 type Config struct {
 	Version int
 
-	Validate struct {
-		Validators []Validator `yaml:"validators"`
-	}
+	Validators []Validator `yaml:"validators"`
 }
 
 type Validator struct {
 	_regex  *regexp.Regexp
-	_maxnum int
+	_maxNum int
 	// Regex for type github is reponame matcher, like `bwplotka\/mdox`.
 	Regex string `yaml:"regex"`
 	// By default type is `roundtrip`. Could be `github`.
 	Type string `yaml:"type"`
 }
 
-func parseConfigFile(configFile string) (Config, error) {
-	if configFile == "" {
+func ParseConfig(c []byte) (Config, error) {
+	if string(c) == "" {
 		return Config{}, nil
 	}
-	configFile, err := filepath.Abs(configFile)
-	if err != nil {
-		return Config{}, errors.Wrap(err, "abs")
-	}
-	c, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return Config{}, errors.Wrap(err, "read config file")
-	}
-	return ParseConfig(c)
-}
-
-func ParseConfig(c []byte) (Config, error) {
 	cfg := Config{}
 	dec := yaml.NewDecoder(bytes.NewReader(c))
 	dec.KnownFields(true)
@@ -53,12 +37,12 @@ func ParseConfig(c []byte) (Config, error) {
 		return Config{}, errors.Wrapf(err, "parsing YAML content %q", string(c))
 	}
 
-	if len(cfg.Validate.Validators) <= 0 {
+	if len(cfg.Validators) <= 0 {
 		return Config{}, errors.New("No validator provided")
 	}
 
-	for i := range cfg.Validate.Validators {
-		cfg.Validate.Validators[i]._regex = regexp.MustCompile(cfg.Validate.Validators[i].Regex)
+	for i := range cfg.Validators {
+		cfg.Validators[i]._regex = regexp.MustCompile(cfg.Validators[i].Regex)
 	}
 	return cfg, nil
 }

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -253,30 +253,10 @@ func (v *validator) visit(filepath string, dest string) {
 	}
 	validator := v.validateConfig.GetValidatorForURL(dest)
 	if validator != nil {
-		matched, err := validator.IsValid(dest)
+		matched, err := validator.IsValid(k, v)
 		if matched && err == nil {
 			return
 		}
-	}
-
-	// Result will be in future.
-	v.destFutures[k].resultFn = func() error { return v.remoteLinks[dest] }
-	v.rMu.RLock()
-	if _, ok := v.remoteLinks[dest]; ok {
-		v.rMu.RUnlock()
-		return
-	}
-	v.rMu.RUnlock()
-
-	v.rMu.Lock()
-	defer v.rMu.Unlock()
-	// We need to check again here to avoid race.
-	if _, ok := v.remoteLinks[dest]; ok {
-		return
-	}
-
-	if err := v.c.Visit(dest); err != nil {
-		v.remoteLinks[dest] = errors.Wrapf(err, "remote link %v", dest)
 	}
 }
 

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -200,6 +200,9 @@ func getGitHubRegex(reponame string) (*regexp.Regexp, int, error) {
 		if err != nil {
 			return nil, math.MaxInt64, err
 		}
+		if respPull.StatusCode != 200 {
+			return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
+		}
 		defer respPull.Body.Close()
 		if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
 			return nil, math.MaxInt64, err
@@ -212,6 +215,9 @@ func getGitHubRegex(reponame string) (*regexp.Regexp, int, error) {
 		respIssue, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "issues"))
 		if err != nil {
 			return nil, math.MaxInt64, err
+		}
+		if respIssue.StatusCode != 200 {
+			return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
 		}
 		defer respIssue.Body.Close()
 		if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -136,9 +136,13 @@ type futureResult struct {
 // NewValidator returns mdformatter.LinkTransformer that crawls all links.
 // TODO(bwplotka): Add optimization and debug modes - this is the main source of latency and pain.
 func NewValidator(logger log.Logger, linksValidateConfig []byte, anchorDir string) (mdformatter.LinkTransformer, error) {
-	config, err := ParseConfig(linksValidateConfig)
-	if err != nil {
-		return nil, err
+	var config Config
+	var err error
+	if string(linksValidateConfig) != "" {
+		config, err = ParseConfig(linksValidateConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 	v := &validator{
 		logger:         logger,

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -239,7 +239,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: 'github'\n    type: 'roundtrip'\n"), anchorDir),
+			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: 'bwplotka'\n    type: 'ignore'\n"), anchorDir),
 		))
 		testutil.Ok(t, err)
 	})

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -140,7 +140,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "", anchorDir),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -157,7 +157,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile, testFile2}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "", anchorDir),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -175,7 +175,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "", anchorDir),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -198,7 +198,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "", anchorDir),
 		))
 		testutil.NotOk(t, err)
 
@@ -224,7 +224,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`^$`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "", anchorDir),
 		))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, fmt.Sprintf("%v%v: %v%v: \"https://bwplotka.dev/does-not-exists\" not accessible; status code 404: Not Found", tmpDir, filePath, relDirPath, filePath), err.Error())
@@ -239,7 +239,21 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, regexp.MustCompile(`://bwplotka.dev`), anchorDir),
+			MustNewValidator(logger, regexp.MustCompile(`://bwplotka.dev`), "", anchorDir),
+		))
+		testutil.Ok(t, err)
+	})
+
+	t.Run("check github links, skipped", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "github-link.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://github.com/bwplotka/mdox/issues/23 https://github.com/bwplotka/mdox/pull/32 https://github.com/bwplotka/mdox/pull/27#pullrequestreview-659598194\n"), os.ModePerm))
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, regexp.MustCompile(`^$`), "bwplotka/mdox", anchorDir),
 		))
 		testutil.Ok(t, err)
 	})

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +63,7 @@ func (v Config) validateGH() error {
 			v.Validators[i]._maxNum = math.MaxInt64
 			continue
 		}
-		regex, maxNum, err := getGitHubRegex(v.Validators[i].Regex)
+		regex, maxNum, err := getGitHubRegex(v.Validators[i].Regex, v.Validators[i].Token)
 		if err != nil {
 			return err
 		}
@@ -75,7 +74,7 @@ func (v Config) validateGH() error {
 }
 
 // getGitHubRegex returns GitHub pulls/issues regex from repo name.
-func getGitHubRegex(repoRe string) (*regexp.Regexp, int, error) {
+func getGitHubRegex(repoRe string, repoToken string) (*regexp.Regexp, int, error) {
 	// Get reponame from regex.
 	getRepo := regexp.MustCompile(`(?P<org>[A-Za-z0-9_.-]+)\\\/(?P<repo>[A-Za-z0-9_.-]+)`)
 	match := getRepo.FindStringSubmatch(repoRe)
@@ -89,7 +88,6 @@ func getGitHubRegex(repoRe string) (*regexp.Regexp, int, error) {
 	max := 0
 	// All GitHub API reqs need to have User-Agent: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required.
 	client := &http.Client{}
-	repoToken := os.Getenv("GITHUB_TOKEN")
 
 	// Check latest pull request number.
 	reqPull, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIURL, reponame, "pulls"), nil)

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -4,140 +4,73 @@
 package linktransformer
 
 import (
-	"encoding/json"
-	"fmt"
-	"math"
-	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
-const (
-	gitHubAPIURL = "https://api.github.com/repos/%v/%v?sort=created&direction=desc&per_page=1"
-)
-
-type GitHubResponse struct {
-	Number int `json:"number"`
+type Validator interface {
+	IsValid(URL string) (bool, error)
 }
 
-type URLValidator struct {
-	Matched bool
+// GitHubValidator.IsValid skips visiting all github issue/PR links.
+func (v GitHubValidator) IsValid(URL string) (bool, error) {
+	// Find rightmost index of match i.e, where regex match ends.
+	// This will be where issue/PR number starts. Split incase of section link and convert to int.
+	rightmostIndex := v._regex.FindStringIndex(URL)
+	stringNum := strings.Split(URL[rightmostIndex[1]:], "#")
+	num, err := strconv.Atoi(stringNum[0])
+	if err != nil {
+		return false, err
+	}
+	// If number in link does not exceed then link is valid.
+	if v._maxNum >= num {
+		return true, nil
+	}
+	return false, nil
 }
 
-// GetValidatorForURL matches link with any one of provided validators.
-func (v Config) GetValidatorForURL(url string) URLValidator {
-	u := URLValidator{Matched: false}
+// RoundTripValidator.IsValid returns false if url matches, to ensure it is visited by colly.
+func (v RoundTripValidator) IsValid(URL string) (bool, error) {
+	return false, nil
+}
+
+// IgnoreValidator.IsValid returns true if matched so that link in not checked.
+func (v IgnoreValidator) IsValid(URL string) (bool, error) {
+	return true, nil
+}
+
+// GetValidatorForURL returns correct Validator by matching URL.
+func (v Config) GetValidatorForURL(URL string) Validator {
+	var u Validator
 	for _, val := range v.Validators {
-		if !val._regex.MatchString(url) {
+		switch val.Type {
+		case roundtripValidator:
+			if !val.rtValidator._regex.MatchString(URL) {
+				continue
+			}
+			u = val.rtValidator
+			return u
+		case githubValidator:
+			if !val.ghValidator._regex.MatchString(URL) {
+				continue
+			}
+			u = val.ghValidator
+			return u
+		case ignoreValidator:
+			if !val.igValidator._regex.MatchString(URL) {
+				continue
+			}
+			u = val.igValidator
+			return u
+		default:
 			continue
 		}
-		if val.Type == roundtrip {
-			u.Matched = true
-			return u
-		}
-		// Find rightmost index of match i.e, where regex match ends.
-		// This will be where issue/PR number starts. Split incase of section link and convert to int.
-		rightmostIndex := val._regex.FindStringIndex(url)
-		stringNum := strings.Split(url[rightmostIndex[1]:], "#")
-		num, err := strconv.Atoi(stringNum[0])
-		// If number in link does not exceed then link is valid. Otherwise will be checked by v.c.Visit.
-		if val._maxNum >= num && err == nil {
-			u.Matched = true
-			return u
-		}
+	}
+	// By default all links are ignored.
+	u = IgnoreValidator{}
+	// No config file passed, so all links must be checked.
+	if len(v.Validators) == 0 {
+		u = nil
 	}
 	return u
-}
-
-// validateGH changes regex and adds maxNum, if type is "github".
-func (v Config) validateGH() error {
-	for i := range v.Validators {
-		if v.Validators[i].Type == roundtrip {
-			continue
-		}
-		if v.Validators[i].Regex == "" {
-			v.Validators[i]._regex = regexp.MustCompile(`^$`)
-			v.Validators[i]._maxNum = math.MaxInt64
-			continue
-		}
-		regex, maxNum, err := getGitHubRegex(v.Validators[i].Regex, v.Validators[i].Token)
-		if err != nil {
-			return err
-		}
-		v.Validators[i]._regex = regex
-		v.Validators[i]._maxNum = maxNum
-	}
-	return nil
-}
-
-// getGitHubRegex returns GitHub pulls/issues regex from repo name.
-func getGitHubRegex(repoRe string, repoToken string) (*regexp.Regexp, int, error) {
-	// Get reponame from regex.
-	getRepo := regexp.MustCompile(`(?P<org>[A-Za-z0-9_.-]+)\\\/(?P<repo>[A-Za-z0-9_.-]+)`)
-	match := getRepo.FindStringSubmatch(repoRe)
-	if len(match) != 3 {
-		return nil, math.MaxInt64, errors.New("repo name regex not valid")
-	}
-	reponame := match[1] + "/" + match[2]
-
-	var pullNum []GitHubResponse
-	var issueNum []GitHubResponse
-	max := 0
-	// All GitHub API reqs need to have User-Agent: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required.
-	client := &http.Client{}
-
-	// Check latest pull request number.
-	reqPull, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIURL, reponame, "pulls"), nil)
-	if err != nil {
-		return nil, math.MaxInt64, err
-	}
-	reqPull.Header.Set("User-Agent", "mdox")
-
-	// Check latest issue number and return whichever is greater.
-	reqIssue, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIURL, reponame, "issues"), nil)
-	if err != nil {
-		return nil, math.MaxInt64, err
-	}
-	reqIssue.Header.Set("User-Agent", "mdox")
-
-	if repoToken != "" {
-		reqPull.Header.Set("Authorization", "Bearer "+repoToken)
-		reqIssue.Header.Set("Authorization", "Bearer "+repoToken)
-	}
-
-	respPull, err := client.Do(reqPull)
-	if err != nil {
-		return nil, math.MaxInt64, err
-	}
-	if respPull.StatusCode != 200 {
-		return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
-	}
-	defer respPull.Body.Close()
-	if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
-		return nil, math.MaxInt64, err
-	}
-
-	respIssue, err := client.Do(reqIssue)
-	if err != nil {
-		return nil, math.MaxInt64, err
-	}
-	if respIssue.StatusCode != 200 {
-		return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
-	}
-	defer respIssue.Body.Close()
-	if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {
-		return nil, math.MaxInt64, err
-	}
-
-	if len(pullNum) > 0 {
-		max = pullNum[0].Number
-	}
-	if len(issueNum) > 0 && issueNum[0].Number > max {
-		max = issueNum[0].Number
-	}
-
-	return regexp.MustCompile(`(^http[s]?:\/\/)(www\.)?(github\.com\/)(` + repoRe + `)(\/pull\/|\/issues\/)`), max, nil
 }

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -1,0 +1,112 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package linktransformer
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	gitHubAPIURL = "https://api.github.com/repos/%v/%v?sort=created&direction=desc&per_page=1"
+)
+
+type GitHubResponse struct {
+	Number int `json:"number"`
+}
+
+// Match link with any one of provided validators.
+func CheckValidators(dest string, v Config) bool {
+	for _, val := range v.Validate.Validators {
+		if val._regex.MatchString(dest) {
+			if val.Type == "github" {
+				// Find rightmost index of match i.e, where regex match ends.
+				// This will be where issue/PR number starts. Split incase of section link and convert to int.
+				idx := val._regex.FindStringIndex(dest)
+				stringNum := strings.Split(dest[idx[1]:], "#")
+				num, err := strconv.Atoi(stringNum[0])
+				// If number in link does not exceed then link is valid. Otherwise will be checked by v.c.Visit.
+				if val._maxnum >= num && err == nil {
+					return true
+				}
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// If type is "github", change regex and add maxnum.
+func CheckGitHub(v Config) error {
+	for i := range v.Validate.Validators {
+		if v.Validate.Validators[i].Type == "github" {
+			regex, maxnum, err := getGitHubRegex(v.Validate.Validators[i].Regex)
+			if err != nil {
+				return err
+			}
+			v.Validate.Validators[i]._regex = regex
+			v.Validate.Validators[i]._maxnum = maxnum
+		}
+	}
+	return nil
+}
+
+// Get GitHub pulls/issues regex from repo name.
+func getGitHubRegex(repoRe string) (*regexp.Regexp, int, error) {
+	if repoRe != "" {
+		// Get reponame from regex.
+		idx := strings.Index(repoRe, `\`)
+		if idx == -1 {
+			return nil, math.MaxInt64, errors.New("repo name regex not valid")
+		}
+		reponame := repoRe[:idx] + repoRe[idx+1:]
+
+		var pullNum []GitHubResponse
+		var issueNum []GitHubResponse
+		max := 0
+		// Check latest pull request number.
+		respPull, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "pulls"))
+		if err != nil {
+			return nil, math.MaxInt64, err
+		}
+		if respPull.StatusCode != 200 {
+			return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
+		}
+		defer respPull.Body.Close()
+		if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
+			return nil, math.MaxInt64, err
+		}
+		if len(pullNum) > 0 {
+			max = pullNum[0].Number
+		}
+
+		// Check latest issue number and return whichever is greater.
+		respIssue, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "issues"))
+		if err != nil {
+			return nil, math.MaxInt64, err
+		}
+		if respIssue.StatusCode != 200 {
+			return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
+		}
+		defer respIssue.Body.Close()
+		if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {
+			return nil, math.MaxInt64, err
+		}
+		if len(issueNum) > 0 && issueNum[0].Number > max {
+			max = issueNum[0].Number
+		}
+
+		return regexp.MustCompile(`(^http[s]?:\/\/)(www\.)?(github\.com\/)(` + repoRe + `)(\/pull\/|\/issues\/)`), max, nil
+	}
+
+	return regexp.MustCompile(`^$`), math.MaxInt64, nil
+}

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -27,24 +27,24 @@ type URLValidator struct {
 	Matched bool
 }
 
-// Match link with any one of provided validators.
+// GetValidatorForURL matches link with any one of provided validators.
 func (v Config) GetValidatorForURL(url string) URLValidator {
 	u := URLValidator{Matched: false}
 	for _, val := range v.Validators {
-		if val._regex.MatchString(url) {
-			if val.Type == "github" {
-				// Find rightmost index of match i.e, where regex match ends.
-				// This will be where issue/PR number starts. Split incase of section link and convert to int.
-				idx := val._regex.FindStringIndex(url)
-				stringNum := strings.Split(url[idx[1]:], "#")
-				num, err := strconv.Atoi(stringNum[0])
-				// If number in link does not exceed then link is valid. Otherwise will be checked by v.c.Visit.
-				if val._maxNum >= num && err == nil {
-					u.Matched = true
-					return u
-				}
-				return u
-			}
+		if !val._regex.MatchString(url) {
+			continue
+		}
+		if val.Type == roundtrip {
+			u.Matched = true
+			return u
+		}
+		// Find rightmost index of match i.e, where regex match ends.
+		// This will be where issue/PR number starts. Split incase of section link and convert to int.
+		rightmostIndex := val._regex.FindStringIndex(url)
+		stringNum := strings.Split(url[rightmostIndex[1]:], "#")
+		num, err := strconv.Atoi(stringNum[0])
+		// If number in link does not exceed then link is valid. Otherwise will be checked by v.c.Visit.
+		if val._maxNum >= num && err == nil {
 			u.Matched = true
 			return u
 		}
@@ -52,69 +52,71 @@ func (v Config) GetValidatorForURL(url string) URLValidator {
 	return u
 }
 
-// If type is "github", change regex and add maxnum.
+// validateGH changes regex and adds maxNum, if type is "github".
 func (v Config) validateGH() error {
 	for i := range v.Validators {
-		if v.Validators[i].Type == "github" {
-			regex, maxNum, err := getGitHubRegex(v.Validators[i].Regex)
-			if err != nil {
-				return err
-			}
-			v.Validators[i]._regex = regex
-			v.Validators[i]._maxNum = maxNum
+		if v.Validators[i].Type == roundtrip {
+			continue
 		}
+		if v.Validators[i].Regex == "" {
+			v.Validators[i]._regex = regexp.MustCompile(`^$`)
+			v.Validators[i]._maxNum = math.MaxInt64
+			continue
+		}
+		regex, maxNum, err := getGitHubRegex(v.Validators[i].Regex)
+		if err != nil {
+			return err
+		}
+		v.Validators[i]._regex = regex
+		v.Validators[i]._maxNum = maxNum
 	}
 	return nil
 }
 
-// Get GitHub pulls/issues regex from repo name.
+// getGitHubRegex returns GitHub pulls/issues regex from repo name.
 func getGitHubRegex(repoRe string) (*regexp.Regexp, int, error) {
-	if repoRe != "" {
-		// Get reponame from regex.
-		getRepo := regexp.MustCompile(`(?P<org>[A-Za-z0-9_.-]+)\\\/(?P<repo>[A-Za-z0-9_.-]+)`)
-		match := getRepo.FindStringSubmatch(repoRe)
-		if len(match) != 3 {
-			return nil, math.MaxInt64, errors.New("repo name regex not valid")
-		}
-		reponame := match[1] + "/" + match[2]
+	// Get reponame from regex.
+	getRepo := regexp.MustCompile(`(?P<org>[A-Za-z0-9_.-]+)\\\/(?P<repo>[A-Za-z0-9_.-]+)`)
+	match := getRepo.FindStringSubmatch(repoRe)
+	if len(match) != 3 {
+		return nil, math.MaxInt64, errors.New("repo name regex not valid")
+	}
+	reponame := match[1] + "/" + match[2]
 
-		var pullNum []GitHubResponse
-		var issueNum []GitHubResponse
-		max := 0
-		// Check latest pull request number.
-		respPull, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "pulls"))
-		if err != nil {
-			return nil, math.MaxInt64, err
-		}
-		if respPull.StatusCode != 200 {
-			return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
-		}
-		defer respPull.Body.Close()
-		if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
-			return nil, math.MaxInt64, err
-		}
-		if len(pullNum) > 0 {
-			max = pullNum[0].Number
-		}
-
-		// Check latest issue number and return whichever is greater.
-		respIssue, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "issues"))
-		if err != nil {
-			return nil, math.MaxInt64, err
-		}
-		if respIssue.StatusCode != 200 {
-			return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
-		}
-		defer respIssue.Body.Close()
-		if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {
-			return nil, math.MaxInt64, err
-		}
-		if len(issueNum) > 0 && issueNum[0].Number > max {
-			max = issueNum[0].Number
-		}
-
-		return regexp.MustCompile(`(^http[s]?:\/\/)(www\.)?(github\.com\/)(` + repoRe + `)(\/pull\/|\/issues\/)`), max, nil
+	var pullNum []GitHubResponse
+	var issueNum []GitHubResponse
+	max := 0
+	// Check latest pull request number.
+	respPull, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "pulls"))
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if respPull.StatusCode != 200 {
+		return nil, math.MaxInt64, errors.New("pulls API request failed. status code: " + strconv.Itoa(respPull.StatusCode))
+	}
+	defer respPull.Body.Close()
+	if err := json.NewDecoder(respPull.Body).Decode(&pullNum); err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if len(pullNum) > 0 {
+		max = pullNum[0].Number
 	}
 
-	return regexp.MustCompile(`^$`), math.MaxInt64, nil
+	// Check latest issue number and return whichever is greater.
+	respIssue, err := http.Get(fmt.Sprintf(gitHubAPIURL, reponame, "issues"))
+	if err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if respIssue.StatusCode != 200 {
+		return nil, math.MaxInt64, errors.New("issues API request failed. status code: " + strconv.Itoa(respIssue.StatusCode))
+	}
+	defer respIssue.Body.Close()
+	if err := json.NewDecoder(respIssue.Body).Decode(&issueNum); err != nil {
+		return nil, math.MaxInt64, err
+	}
+	if len(issueNum) > 0 && issueNum[0].Number > max {
+		max = issueNum[0].Number
+	}
+
+	return regexp.MustCompile(`(^http[s]?:\/\/)(www\.)?(github\.com\/)(` + repoRe + `)(\/pull\/|\/issues\/)`), max, nil
 }


### PR DESCRIPTION
This PR adds in the `--links.validate.config` flag which allows users to pass in path to YAML config with composable regex matchers. 

A sample yaml config would be,
```
validators:
  - regex: 'bwplotka\/mdox'
    token: '$(GITHUB_TOKEN)'
    type: "github"
  - regex: '(^http[s]?:\/\/)(www\.)?(fakelink[0-9]\.com\/)'
    type: "ignore"
  - regex: 'mycustomdomain'
    type: "roundtrip"
```

Here, all links are checked with default type `ignore`, i.e, links are not visited. If type is set to `roundtrip`, then links matching provided regex are visited by colly. For type `github` only repo name regex is taken, which then directs mdox to not visit any GitHub issue/PR link of that repo. User can also provide a token(env var substitution) to tackle GitHub API rate limiting.

Also, we don't check if a particular number is an issue or a PR since GitHub can automatically redirect such links to the correct page, for example the link`https://github.com/bwplotka/mdox/pull/30` is actually an issue and will be redirected. So such links can be safely skipped.