### PR TITLE
Fixed mdox gen errors on command with `=` inside (common case).

### DIFF
--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -4,10 +4,6 @@
 test output
 ```
 
-```yaml mdox-gen-lang="go" mdox-gen-type="github.com/bwplotka/mdox/pkg/mdox/testdata.Config"
-TO BE DONE
-```
-
 ```yaml
 abc
 sad
@@ -39,4 +35,9 @@ test output3
 #!/usr/bin/env bash
 
 echo "test output3"
+```
+
+```yaml mdox-exec="bash ./testdata/out2.sh --name=queryfrontend.InMemoryResponseCacheConfig"
+test output2
+newline
 ```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -6,10 +6,6 @@ a
 adf
 ```
 
-```yaml mdox-gen-lang="go" mdox-gen-type="github.com/bwplotka/mdox/pkg/mdox/testdata.Config"
-TO BE DONE
-```
-
 ```yaml
 abc
 sad
@@ -40,4 +36,7 @@ abc
 ```
 
 ```bash mdox-exec="sed -n '1,3p' ./testdata/out3.sh"
+```
+
+```yaml mdox-exec="bash ./testdata/out2.sh --name=queryfrontend.InMemoryResponseCacheConfig"
 ```


### PR DESCRIPTION
Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>