### PR TITLE
Add CI for docs and fix dash header ID

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,31 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name:  Documentation check
+    env:
+      GOBIN: /tmp/.bin
+    steps:
+      - name: Checkout code into the Go module directory.
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Check docs
+        run: make check-docs

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ docs: build ## Generates config snippets and doc formatting.
 	@echo ">> generating docs $(PATH)"
 	@PATH=$(GOBIN) mdox fmt -l *.md
 
+.PHONY: check-docs
+check-docs: build ## Checks docs for discrepancies in formatting and links.
+	@echo ">> checking formatting and links $(PATH)"
+	@PATH=$(GOBIN) mdox fmt --check -l *.md
+
 .PHONY: format
 format: ## Formats Go code.
 format: $(GOIMPORTS)

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Flags:
       --links.validate.config-file=<file-path>  
                                  Path to YAML file for skipping link check, with
                                  spec defined in
-                                 github.com/bwplotka/mdox/pkg/linktransformer.Config
+                                 github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
       --links.validate.config=<content>  
                                  Alternative to 'links.validate.config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
-                                 github.com/bwplotka/mdox/pkg/linktransformer.Config
+                                 github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
 
 Args:
   <files>  Markdown file(s) to process.

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
 	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
-	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.Config", extflag.WithEnvSubstitution())
+	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig", extflag.WithEnvSubstitution())
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var opts []mdformatter.Option

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -351,7 +351,7 @@ func toHeaderID(header []byte) string {
 		switch h {
 		case '{':
 			return string(id)
-		case ' ':
+		case ' ', '-':
 			id = append(id, '-')
 		default:
 		}

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -181,6 +181,28 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 	})
 
+	t.Run("check valid local links with dash", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links-with-dash.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# Expose UI on a sub-path
+
+[1](#expose-ui-on-a-sub-path)
+
+# Run-time deduplication of HA groups
+
+[2](#run-time-deduplication-of-ha-groups)
+`), os.ModePerm))
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, []byte(""), anchorDir),
+		))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+	})
+
 	t.Run("check invalid local links", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-local-links.md")
 		filePath := "/repo/docs/test/invalid-local-links.md"


### PR DESCRIPTION
This PR adds in CI for documentation check and make sure `links.validate.config` points to correct struct as mentioned in #42 . Also fixes markdown header ID issue and fixes #43.