### PR TITLE
Change transform config flag to `pathorcontent`

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,9 +209,12 @@ func validateAnchorDir(anchorDir string, files []string) (_ string, err error) {
 
 func registerTransform(_ context.Context, app *extkingpin.App) {
 	cmd := app.Command("transform", "Transform markdown files in various ways. For example pre process markdown files to allow it for use for popular static HTML websites based on markdown source code and front matter options.")
-	cfg := cmd.Flag("config", "Path to the YAML file with spec defined in github.com/bwplotka/mdox/pkg/transform.Config").
-		Short('c').Default(".mdox.yaml").ExistingFile()
+	cfg := extflag.RegisterPathOrContent(cmd, "config", "Path to the YAML file with spec defined in github.com/bwplotka/mdox/pkg/transform.Config", extflag.WithEnvSubstitution())
 	cmd.Run(func(ctx context.Context, logger log.Logger) error {
-		return transform.Dir(ctx, logger, *cfg)
+		validateConfig, err := cfg.Content()
+		if err != nil {
+			return err
+		}
+		return transform.Dir(ctx, logger, validateConfig)
 	})
 }

--- a/pkg/transform/config.go
+++ b/pkg/transform/config.go
@@ -5,7 +5,6 @@ package transform
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,18 +113,6 @@ type FrontMatterConfig struct {
 	// This will override any existing font matter.1
 	// TODO(bwplotka): Add add only option?
 	Template string
-}
-
-func parseConfigFile(configFile string) (Config, error) {
-	configFile, err := filepath.Abs(configFile)
-	if err != nil {
-		return Config{}, errors.Wrap(err, "abs")
-	}
-	c, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return Config{}, errors.Wrap(err, "read config file")
-	}
-	return ParseConfig(c)
 }
 
 func ParseConfig(c []byte) (Config, error) {

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -49,8 +49,8 @@ func prepOutputDir(d string, gitIgnored bool) error {
 }
 
 // Dir transforms directory using given configuration file.
-func Dir(ctx context.Context, logger log.Logger, configFile string) error {
-	c, err := parseConfigFile(configFile)
+func Dir(ctx context.Context, logger log.Logger, config []byte) error {
+	c, err := ParseConfig(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/transform/transform_e2e_test.go
+++ b/pkg/transform/transform_e2e_test.go
@@ -28,11 +28,15 @@ func TestTransform(t *testing.T) {
 
 	testutil.Ok(t, os.RemoveAll(tmpDir))
 	t.Run("mdox1.yaml", func(t *testing.T) {
-		testutil.Ok(t, transform.Dir(context.Background(), logger, filepath.Join(testData, "mdox1.yaml")))
+		mdox1, err := ioutil.ReadFile(filepath.Join(testData, "mdox1.yaml"))
+		testutil.Ok(t, err)
+		testutil.Ok(t, transform.Dir(context.Background(), logger, mdox1))
 		assertDirContent(t, filepath.Join(testData, "expected", "test1"), filepath.Join(tmpDir, "test1"))
 	})
 	t.Run("mdox2.yaml", func(t *testing.T) {
-		testutil.Ok(t, transform.Dir(context.Background(), logger, filepath.Join(testData, "mdox2.yaml")))
+		mdox2, err := ioutil.ReadFile(filepath.Join(testData, "mdox2.yaml"))
+		testutil.Ok(t, err)
+		testutil.Ok(t, transform.Dir(context.Background(), logger, mdox2))
 		assertDirContent(t, filepath.Join(testData, "expected", "test2"), filepath.Join(tmpDir, "test2"))
 
 	})


### PR DESCRIPTION
This PR changes transform config flag to `pathorcontent`. A particular use case for this would be dynamic input and output dirs (for example when transforming docs for multiple releases of a project).