### PR TITLE
Fix i18n section links

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -392,7 +392,7 @@ func toHeaderID(header []byte) string {
 	punctuation := regexp.MustCompile(`[^\p{L}\p{N}\p{M}-# ]`)
 	header = punctuation.ReplaceAll(header, []byte(""))
 	headerText := bytes.TrimLeft(bytes.ToLower(header), "#")
-	// If header is just punctuation it comes up empty. So cannot be linked.
+	// If header is just punctuation it comes up empty, so it cannot be linked.
 	if len(headerText) <= 1 {
 		return ""
 	}

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -203,6 +203,28 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 	})
 
+	t.Run("check valid local links in diff language", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links-diff-lang.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# Twój wkład w dokumentację
+
+[1](#twój-wkład-w-dokumentację)
+
+## Hugo का उपयोग करते हुए स्थानीय रूप से साइट चलाना
+
+[2](#hugo-का-उपयोग-करते-हुए-स्थानीय-रूप-से-साइट-चलाना)
+`), os.ModePerm))
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, []byte(""), anchorDir),
+		))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+	})
+
 	t.Run("check invalid local links", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-local-links.md")
 		filePath := "/repo/docs/test/invalid-local-links.md"


### PR DESCRIPTION
This PR converts `toHeaderID` function to use a unicode regex to generate header ids for any given language instead of using ascii codes which restrict section links to just English. Test case added as well. Fixes #50.