### PR TITLE
Add link caching using SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor/
 
 .idea/
 .envrc
+mdoxcache

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ vendor/
 
 .idea/
 .envrc
-mdoxcache
+.mdoxcache

--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,4 +1,5 @@
 version: 1
+noCache: true
 
 validators:
   # Validators to skip checking PR/issue links of mdox.

--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,5 +1,4 @@
 version: 1
-noCache: true
 
 validators:
   # Validators to skip checking PR/issue links of mdox.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Flags:
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
-      --cache.clear              If true, entire cache database will be dropped
+      --cache.clear              If true, entire cache database will be dropped.
+                                 Useful in case mdox cache needs to be cleared
+                                 immediately from GitHub Actions or other CI
+                                 runner cache.
 
 Args:
   <files>  Markdown file(s) to process.

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Flags:
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
-      --cache.clear              If true, entire cache database will be dropped.
-                                 Useful in case mdox cache needs to be cleared
-                                 immediately from GitHub Actions or other CI
-                                 runner cache.
+      --cache.clear              If true, entire cache database will be dropped
+                                 and rebuilt when mdox is run. Useful in case
+                                 cache needs to be cleared immediately from
+                                 GitHub Actions or other CI runner cache.
 
 Args:
   <files>  Markdown file(s) to process.

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ Flags:
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
-      --no-cache                 If true, link checking will not create local
-                                 SQLite cache file
-      --cache.validity=120h      Duration till which link in cache is considered
-                                 valid
       --cache.clear              If true, entire cache database will be dropped
 
 Args:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Flags:
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
+      --no-cache                 If true, link checking will not create local
+                                 SQLite cache file
+      --cache.validity=120h      Duration till which link in cache is considered
+                                 valid
+      --cache.clear              If true, entire cache database will be dropped
 
 Args:
   <files>  Markdown file(s) to process.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gohugoio/hugo v0.101.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-shellwords v1.0.10
+	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -544,6 +544,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.10 h1:Y7Xqm8piKOO3v10Thp7Z36h4FYFjt5xB//6XvOrs2Gw=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
+github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.17 h1:Z1a//hgsQ4yjC+8zEkV8IWySkXnsxmdSY642CTFQb5Y=

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bwplotka/mdox/pkg/cache"
 	"github.com/bwplotka/mdox/pkg/clilog"
 	"github.com/bwplotka/mdox/pkg/extkingpin"
 	"github.com/bwplotka/mdox/pkg/mdformatter"
@@ -40,6 +41,8 @@ const (
 	logFormatLogfmt = "logfmt"
 	logFormatJson   = "json"
 	logFormatCLILog = "clilog"
+
+	cacheFile = "mdoxcache"
 )
 
 func setupLogger(logLevel, logFormat string) log.Logger {
@@ -207,9 +210,13 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	anchorDir := cmd.Flag("anchor-dir", "Anchor directory for all transformers. PWD is used if flag is not specified.").ExistingDir()
 	linksLocalizeForAddress := cmd.Flag("links.localize.address-regex", "If specified, all HTTP(s) links that target a domain and path matching given regexp will be transformed to relative to anchor dir path (if exists)."+
 		"Absolute path links will be converted to relative links to anchor dir as well.").Regexp()
-	// TODO(bwplotka): Add cache in file?
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig", extflag.WithEnvSubstitution())
+
+	cacheDisabled := cmd.Flag("no-cache", "If true, link checking will not create local SQLite cache file").Bool()
+	// Default validity is for 5 days.
+	cacheValidity := cmd.Flag("cache.validity", "Duration till which link in cache is considered valid").Default("120h").Duration()
+	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped").Bool()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var reg *prometheus.Registry
@@ -242,11 +249,23 @@ This directive runs executable with arguments and put its stderr and stdout outp
 
 		var linkTr []mdformatter.LinkTransformer
 		if *linksValidateEnabled {
+			var storage *cache.Storage
+
 			validateConfigContent, err := linksValidateConfig.Content()
 			if err != nil {
 				return err
 			}
-			v, err := linktransformer.NewValidator(ctx, logger, validateConfigContent, anchorDir, reg)
+
+			storage = nil
+			if !*cacheDisabled {
+				storage = &cache.Storage{
+					Filename:   cacheFile,
+					Validity:   *cacheValidity,
+					ClearCache: *clearCache,
+				}
+			}
+
+			v, err := linktransformer.NewValidator(ctx, logger, validateConfigContent, anchorDir, storage, reg)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -213,9 +213,6 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig", extflag.WithEnvSubstitution())
 
-	cacheDisabled := cmd.Flag("no-cache", "If true, link checking will not create local SQLite cache file").Bool()
-	// Default validity is for 5 days.
-	cacheValidity := cmd.Flag("cache.validity", "Duration till which link in cache is considered valid").Default("120h").Duration()
 	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped").Bool()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
@@ -256,13 +253,9 @@ This directive runs executable with arguments and put its stderr and stdout outp
 				return err
 			}
 
-			storage = nil
-			if !*cacheDisabled {
-				storage = &cache.Storage{
-					Filename:   cacheFile,
-					Validity:   *cacheValidity,
-					ClearCache: *clearCache,
-				}
+			storage = &cache.Storage{
+				Filename:   cacheFile,
+				ClearCache: *clearCache,
 			}
 
 			v, err := linktransformer.NewValidator(ctx, logger, validateConfigContent, anchorDir, storage, reg)

--- a/main.go
+++ b/main.go
@@ -246,14 +246,14 @@ This directive runs executable with arguments and put its stderr and stdout outp
 
 		var linkTr []mdformatter.LinkTransformer
 		if *linksValidateEnabled {
-			var storage *cache.Storage
+			var storage *cache.SQLite3Storage
 
 			validateConfigContent, err := linksValidateConfig.Content()
 			if err != nil {
 				return err
 			}
 
-			storage = &cache.Storage{
+			storage = &cache.SQLite3Storage{
 				Filename:   cacheFile,
 				ClearCache: *clearCache,
 			}

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ const (
 	logFormatJson   = "json"
 	logFormatCLILog = "clilog"
 
-	cacheFile = "mdoxcache"
+	cacheFile = ".mdoxcache"
 )
 
 func setupLogger(logLevel, logFormat string) log.Logger {
@@ -213,7 +213,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig", extflag.WithEnvSubstitution())
 
-	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped").Bool()
+	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped. Useful in case mdox cache needs to be cleared immediately from GitHub Actions or other CI runner cache.").Bool()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var reg *prometheus.Registry

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ This directive runs executable with arguments and put its stderr and stdout outp
 	linksValidateEnabled := cmd.Flag("links.validate", "If true, all links will be validated").Short('l').Bool()
 	linksValidateConfig := extflag.RegisterPathOrContent(cmd, "links.validate.config", "YAML file for skipping link check, with spec defined in github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig", extflag.WithEnvSubstitution())
 
-	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped. Useful in case mdox cache needs to be cleared immediately from GitHub Actions or other CI runner cache.").Bool()
+	clearCache := cmd.Flag("cache.clear", "If true, entire cache database will be dropped and rebuilt when mdox is run. Useful in case cache needs to be cleared immediately from GitHub Actions or other CI runner cache.").Bool()
 
 	cmd.Run(func(ctx context.Context, logger log.Logger) (err error) {
 		var reg *prometheus.Registry

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,160 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"database/sql"
+	"net/url"
+	"sync"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+const (
+	driverName = "sqlite3"
+)
+
+// Storage implements a SQLite3 caching backend for Colly.
+type Storage struct {
+	// Sqlite filename.
+	Filename string
+	// Duration till which a link is skipped.
+	Validity time.Duration
+	// Clear cache at start if true.
+	ClearCache bool
+	// Database handle.
+	dbHandle *sql.DB
+	// Mutex used for clearing cache database.
+	mu sync.RWMutex
+}
+
+// Init initializes cache database.
+func (s *Storage) Init() error {
+	// Check if db exists.
+	if s.dbHandle == nil {
+		database, err := sql.Open(driverName, s.Filename)
+		if err != nil {
+			return errors.Wrap(err, "unable to open cache database file")
+		}
+
+		err = database.Ping()
+		if err != nil {
+			return errors.Wrap(err, "verify connection to cache database")
+		}
+		s.dbHandle = database
+	}
+	if s.ClearCache {
+		err := s.Clear()
+		if err != nil {
+			return err
+		}
+	}
+	// Create db with index.
+	statement, err := s.dbHandle.Prepare("CREATE TABLE IF NOT EXISTS visited (id INTEGER PRIMARY KEY, requestID INTEGER, visited INT, timestamp DATETIME)")
+	if err != nil {
+		return err
+	}
+	_, err = statement.Exec()
+	if err != nil {
+		return err
+	}
+	statement, err = s.dbHandle.Prepare("CREATE INDEX IF NOT EXISTS idx_visited ON visited (requestID)")
+	if err != nil {
+		return err
+	}
+	_, err = statement.Exec()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Clear removes all entries from cache.
+func (s *Storage) Clear() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	statement, err := s.dbHandle.Prepare("DROP TABLE visited")
+	if err != nil {
+		return err
+	}
+	_, err = statement.Exec()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close cache database.
+func (s *Storage) Close() error {
+	err := s.dbHandle.Close()
+	return err
+}
+
+// Visited inserts new URL to cache database.
+func (s *Storage) Visited(requestID uint64) error {
+	// If particular URL is already inserted, then delete.
+	// Visit method will only be called if validity expires for a URL or in case of a new URL.
+	err := s.DeleteRequest(requestID)
+	if err != nil {
+		return err
+	}
+
+	// Insert with current UTC Unix timestamp.
+	statement, err := s.dbHandle.Prepare("INSERT INTO visited (requestID, visited, timestamp) VALUES (?, 1, strftime('%s', 'now'))")
+	if err != nil {
+		return err
+	}
+	_, err = statement.Exec(int64(requestID))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsVisited checks if URL has already been visited.
+func (s *Storage) IsVisited(requestID uint64) (bool, error) {
+	var timestamp time.Time
+	statement, err := s.dbHandle.Prepare("SELECT timestamp FROM visited where requestId = ?")
+	if err != nil {
+		return false, err
+	}
+	row := statement.QueryRow(int64(requestID))
+	err = row.Scan(&timestamp)
+	if err != nil {
+		// If ErrNoRows then it means URL is new, so need to call Visited.
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Check if URL is within validity threshold.
+	now := time.Now().UTC()
+	if !timestamp.IsZero() && now.Sub(timestamp) <= s.Validity {
+		return true, nil
+	}
+	return false, nil
+}
+
+// DeleteRequest deletes a request from cache database.
+func (s *Storage) DeleteRequest(requestID uint64) error {
+	statement, err := s.dbHandle.Prepare("DELETE FROM visited where requestId = ?")
+	if err != nil {
+		return err
+	}
+	_, err = statement.Exec(int64(requestID))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Cookie methods are not implemented, as saving cookies is not a requirement for link caching.
+func (s *Storage) SetCookies(u *url.URL, cookies string) {}
+
+func (s *Storage) Cookies(u *url.URL) string {
+	return ""
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,7 +145,7 @@ func (s *SQLite3Storage) IsCached(URL string) (bool, error) {
 		jitterValue = time.Duration(s.r.Intn(int(s.Jitter)))
 	}
 
-	return (!timestamp.IsZero() && time.Now().UTC().Sub(timestamp)+jitterValue <= s.Validity), nil
+	return (!timestamp.IsZero() && time.Since(timestamp)+jitterValue <= s.Validity), nil
 }
 
 // DeleteURL deletes a URL from cache database.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -44,28 +44,30 @@ func (s *Storage) Init() error {
 		}
 		s.dbHandle = database
 	}
+
 	if s.ClearCache {
 		if err := s.Clear(); err != nil {
 			return err
 		}
 	}
+
 	// Create db with index.
 	statement, err := s.dbHandle.Prepare("CREATE TABLE IF NOT EXISTS visited (id INTEGER PRIMARY KEY, url TEXT, visited INT, timestamp DATETIME)")
 	if err != nil {
 		return err
 	}
-	_, err = statement.Exec()
-	if err != nil {
+	if _, err = statement.Exec(); err != nil {
 		return err
 	}
+
 	statement, err = s.dbHandle.Prepare("CREATE INDEX IF NOT EXISTS idx_visited ON visited (url)")
 	if err != nil {
 		return err
 	}
-	_, err = statement.Exec()
-	if err != nil {
+	if _, err = statement.Exec(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -73,14 +75,15 @@ func (s *Storage) Init() error {
 func (s *Storage) Clear() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	statement, err := s.dbHandle.Prepare("DROP TABLE visited")
 	if err != nil {
 		return err
 	}
-	_, err = statement.Exec()
-	if err != nil {
+	if _, err = statement.Exec(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -102,10 +105,10 @@ func (s *Storage) CacheURL(URL string) error {
 	if err != nil {
 		return err
 	}
-	_, err = statement.Exec(URL)
-	if err != nil {
+	if _, err = statement.Exec(URL); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -136,8 +139,5 @@ func (s *Storage) DeleteURL(URL string) error {
 		return err
 	}
 	_, err = statement.Exec(URL)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -75,6 +75,8 @@ const (
 
 	none   = "None"
 	sqlite = "SQLite"
+
+	defaultValidity = time.Duration(432000000000000)
 )
 
 type GitHubResponse struct {
@@ -82,10 +84,6 @@ type GitHubResponse struct {
 }
 
 func ParseConfig(c []byte) (Config, error) {
-	defaultValidity, err := time.ParseDuration("120h")
-	if err != nil {
-		return Config{}, errors.Wrapf(err, "parsing default validity %q", string(c))
-	}
 	cfg := Config{CacheValidity: defaultValidity}
 	dec := yaml.NewDecoder(bytes.NewReader(c))
 	dec.KnownFields(true)

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -22,6 +22,7 @@ type Config struct {
 
 	CacheType     string        `yaml:"cacheType"`
 	CacheValidity time.Duration `yaml:"cacheValidity"`
+	CacheJitter   time.Duration `yaml:"cacheJitter"`
 
 	ExplicitLocalValidators bool              `yaml:"explicitLocalValidators"`
 	Validators              []ValidatorConfig `yaml:"validators"`

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -20,9 +20,7 @@ import (
 type Config struct {
 	Version int
 
-	CacheType     string        `yaml:"cacheType"`
-	CacheValidity time.Duration `yaml:"cacheValidity"`
-	CacheJitter   time.Duration `yaml:"cacheJitter"`
+	Cache CacheConfig `yaml:"cache"`
 
 	ExplicitLocalValidators bool              `yaml:"explicitLocalValidators"`
 	Validators              []ValidatorConfig `yaml:"validators"`
@@ -35,6 +33,12 @@ type Config struct {
 
 	timeout     time.Duration
 	randomDelay time.Duration
+}
+
+type CacheConfig struct {
+	Type     string        `yaml:"type"`
+	Validity time.Duration `yaml:"validity"`
+	Jitter   time.Duration `yaml:"jitter"`
 }
 
 type ValidatorConfig struct {
@@ -85,7 +89,7 @@ type GitHubResponse struct {
 }
 
 func ParseConfig(c []byte) (Config, error) {
-	cfg := Config{CacheValidity: defaultValidity}
+	cfg := Config{Cache: CacheConfig{Validity: defaultValidity}}
 	dec := yaml.NewDecoder(bytes.NewReader(c))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
@@ -112,10 +116,10 @@ func ParseConfig(c []byte) (Config, error) {
 		return Config{}, errors.New("parsing parallelism, has to be > 0")
 	}
 
-	switch cfg.CacheType {
+	switch cfg.Cache.Type {
 	case none, sqlite, "":
 	default:
-		return Config{}, errors.New("unsupported cacheType")
+		return Config{}, errors.New("unsupported cache type")
 	}
 
 	if len(cfg.Validators) <= 0 {

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -20,7 +20,7 @@ import (
 type Config struct {
 	Version int
 
-	NoCache       bool          `yaml:"noCache"`
+	CacheType     string        `yaml:"cacheType"`
 	CacheValidity time.Duration `yaml:"cacheValidity"`
 
 	ExplicitLocalValidators bool              `yaml:"explicitLocalValidators"`
@@ -72,6 +72,9 @@ const (
 
 const (
 	gitHubAPIURL = "https://api.github.com/repos/%v/%v?sort=created&direction=desc&per_page=1"
+
+	none   = "None"
+	sqlite = "SQLite"
 )
 
 type GitHubResponse struct {
@@ -108,6 +111,12 @@ func ParseConfig(c []byte) (Config, error) {
 
 	if cfg.Parallelism < 0 {
 		return Config{}, errors.New("parsing parallelism, has to be > 0")
+	}
+
+	switch cfg.CacheType {
+	case none, sqlite, "":
+	default:
+		return Config{}, errors.New("unsupported cacheType")
 	}
 
 	if len(cfg.Validators) <= 0 {

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -81,7 +81,8 @@ const (
 	none   = "None"
 	sqlite = "SQLite"
 
-	defaultValidity = time.Duration(432000000000000)
+	timeDay         = 24 * time.Hour
+	defaultValidity = 5 * timeDay
 )
 
 type GitHubResponse struct {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -267,7 +267,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		v.c.SetRequestTimeout(config.timeout)
 	}
 
-	if !v.validateConfig.NoCache && storage != nil {
+	if v.validateConfig.CacheType == sqlite && storage != nil {
 		v.storage = storage
 		v.storage.Validity = v.validateConfig.CacheValidity
 		if err = v.storage.Init(); err != nil {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"hash/fnv"
 	"io"
 	"net"
 	"net/http"
@@ -202,7 +201,11 @@ type futureResult struct {
 // TODO(bwplotka): Add optimization and debug modes - this is the main source of latency and pain.
 func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []byte, anchorDir string, storage *cache.Storage, reg *prometheus.Registry) (mdformatter.LinkTransformer, error) {
 	var err error
-	config := Config{}
+	defaultValidity, err := time.ParseDuration("120h")
+	if err != nil {
+		return nil, err
+	}
+	config := Config{CacheValidity: defaultValidity}
 	if string(linksValidateConfig) != "" {
 		config, err = ParseConfig(linksValidateConfig)
 		if err != nil {
@@ -234,7 +237,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		localLinks:     map[string]*[]string{},
 		remoteLinks:    map[string]error{},
 		c:              colly.NewCollector(colly.Async(), colly.StdlibContext(ctx)),
-		storage:        storage,
+		storage:        nil,
 		destFutures:    map[futureKey]*futureResult{},
 		l:              linktransformerMetrics,
 		transportFn: func(u string) http.RoundTripper {
@@ -259,8 +262,10 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		v.c.SetRequestTimeout(config.timeout)
 	}
 
-	if v.storage != nil {
-		err = v.c.SetStorage(v.storage)
+	if !v.validateConfig.NoCache && storage != nil {
+		v.storage = storage
+		v.storage.Validity = v.validateConfig.CacheValidity
+		err = v.storage.Init()
 		if err != nil {
 			return nil, err
 		}
@@ -287,25 +292,17 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 	v.c.OnScraped(func(response *colly.Response) {
 		v.rMu.Lock()
 		defer v.rMu.Unlock()
+		if v.storage != nil {
+			err := v.storage.CacheURL(response.Ctx.Get(originalURLKey))
+			if err != nil {
+				v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(err, "remote link not saved to cache %v", response.Ctx.Get(originalURLKey))
+			}
+		}
 		v.remoteLinks[response.Ctx.Get(originalURLKey)] = nil
 	})
 	v.c.OnError(func(response *colly.Response, err error) {
 		v.rMu.Lock()
 		defer v.rMu.Unlock()
-		// Colly stores requests in cache, even when they have errors.
-		// So need to delete requests with errors from cache database.
-		if v.storage != nil {
-			h := fnv.New64a()
-			_, writeErr := h.Write([]byte(response.Ctx.Get(originalURLKey)))
-			if writeErr != nil {
-				v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(writeErr, "%q could not build requestID %v", response.Request.URL.String(), response.StatusCode)
-			}
-			delErr := v.storage.DeleteRequest(h.Sum64())
-			if delErr != nil {
-				v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(delErr, "%q could not delete from cache %v", response.Request.URL.String(), response.StatusCode)
-			}
-		}
-
 		retriesStr := response.Ctx.Get(numberOfRetriesKey)
 		retries, _ := strconv.Atoi(retriesStr)
 		switch response.StatusCode {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -265,7 +265,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 
 	if v.validateConfig.CacheType != none && storage != nil {
 		v.storage = storage
-		if err = v.storage.Init(v.validateConfig.CacheValidity); err != nil {
+		if err = v.storage.Init(v.validateConfig.CacheValidity, v.validateConfig.CacheJitter); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/mdformatter/linktransformer/link_bench_test.go
+++ b/pkg/mdformatter/linktransformer/link_bench_test.go
@@ -49,7 +49,7 @@ func benchLinktransformer(b *testing.B) {
 	testutil.Ok(b, err)
 	defer file.Close()
 
-	f := mdformatter.New(context.Background(), mdformatter.WithLinkTransformer(MustNewValidator(logger, []byte(""), anchorDir)))
+	f := mdformatter.New(context.Background(), mdformatter.WithLinkTransformer(MustNewValidator(logger, []byte(""), anchorDir, nil)))
 	b.ResetTimer()
 	b.Run("Validator", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -387,7 +387,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		}
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("cacheType: 'SQLite'"), anchorDir, testStorage),
 		))
 
 		testutil.Ok(t, err)
@@ -422,7 +422,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		}
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\nnoCache: true"), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("version: 1\n\ncacheType: 'None'"), anchorDir, testStorage),
 		))
 
 		testutil.Ok(t, err)
@@ -452,7 +452,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("cacheType: 'SQLite'"), anchorDir, testStorage),
 		))
 		testutil.NotOk(t, err)
 

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -140,7 +140,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -157,7 +157,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile, testFile2}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -175,7 +175,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -197,7 +197,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -219,7 +219,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -242,7 +242,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.NotOk(t, err)
 
@@ -263,7 +263,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 		testutil.Equals(t, 0, len(diff), diff.String())
@@ -283,7 +283,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, fmt.Sprintf("%v: "+"%v:1: provided mailto link is not a valid email, got mailto:test@mdox.com", tmpDir+filePath, relDirPath+filePath), err.Error())
@@ -303,7 +303,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte(""), anchorDir),
+			MustNewValidator(logger, []byte(""), anchorDir, nil),
 		))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, fmt.Sprintf("%v: 2 errors: "+
@@ -320,7 +320,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: 'bwplotka'\n    type: 'ignore'\n"), anchorDir),
+			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: 'bwplotka'\n    type: 'ignore'\n"), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 	})
@@ -334,7 +334,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: '(^http[s]?:\\/\\/)(www\\.)?(fakelink[0-9]\\.com\\/)'\n    type: 'ignore'\n"), anchorDir),
+			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: '(^http[s]?:\\/\\/)(www\\.)?(fakelink[0-9]\\.com\\/)'\n    type: 'ignore'\n"), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 	})
@@ -350,7 +350,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: '(^http[s]?:\\/\\/)(www\\.)?(github\\.com\\/)bwplotka\\/mdox(\\/pull\\/|\\/issues\\/)'\n    token: '"+repoToken+"'\n    type: 'githubPullsIssues'\n"), anchorDir),
+			MustNewValidator(logger, []byte("version: 1\n\nvalidators:\n  - regex: '(^http[s]?:\\/\\/)(www\\.)?(github\\.com\\/)bwplotka\\/mdox(\\/pull\\/|\\/issues\\/)'\n    token: '"+repoToken+"'\n    type: 'githubPullsIssues'\n"), anchorDir, nil),
 		))
 		testutil.Ok(t, err)
 	})

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -382,12 +382,12 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
 		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
-		testStorage := &cache.Storage{
+		testStorage := &cache.SQLite3Storage{
 			Filename: filepath.Join(tmpDir, "repo", "docs", "test", "mdoxcachetest"),
 		}
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("cacheType: 'SQLite'"), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("version: 1\n\ncache:\n  type: 'SQLite'"), anchorDir, testStorage),
 		))
 
 		testutil.Ok(t, err)
@@ -417,12 +417,12 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
 		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
-		testStorage := &cache.Storage{
+		testStorage := &cache.SQLite3Storage{
 			Filename: filepath.Join(tmpDir, "repo", "docs", "test", "mdoxcachetest2"),
 		}
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("version: 1\n\ncacheType: 'None'"), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("version: 1\n\ncache:\n  type: 'None'"), anchorDir, testStorage),
 		))
 
 		testutil.Ok(t, err)
@@ -443,7 +443,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Ok(t, err)
 
 		var id int
-		testStorage := &cache.Storage{
+		testStorage := &cache.SQLite3Storage{
 			Filename: filepath.Join(tmpDir, "repo", "docs", "test", "mdoxcachetest3"),
 		}
 
@@ -452,7 +452,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Equals(t, 0, len(diff), diff.String())
 
 		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
-			MustNewValidator(logger, []byte("cacheType: 'SQLite'"), anchorDir, testStorage),
+			MustNewValidator(logger, []byte("version: 1\n\ncache:\n  type: 'SQLite'"), anchorDir, testStorage),
 		))
 		testutil.NotOk(t, err)
 

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -58,6 +58,12 @@ func (v RoundTripValidator) IsValid(k futureKey, r *validator) (bool, error) {
 	}
 
 	r.c.WithTransport(r.transportFn(k.dest))
+	if r.storage != nil {
+		// Check if URL is already in cache database.
+		if ok, err := r.c.HasVisited(k.dest); ok && err == nil {
+			return true, nil
+		}
+	}
 	if err := r.c.Visit(k.dest); err != nil {
 		r.remoteLinks[k.dest] = errors.Wrapf(err, "remote link %v", k.dest)
 		return false, nil

--- a/pkg/mdformatter/linktransformer/validator.go
+++ b/pkg/mdformatter/linktransformer/validator.go
@@ -60,7 +60,7 @@ func (v RoundTripValidator) IsValid(k futureKey, r *validator) (bool, error) {
 	r.c.WithTransport(r.transportFn(k.dest))
 	if r.storage != nil {
 		// Check if URL is already in cache database.
-		if ok, err := r.c.HasVisited(k.dest); ok && err == nil {
+		if ok, err := r.storage.IsCached(k.dest); ok && err == nil {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
This PR adds link caching using a local SQLite file, `.mdoxcache` which is suitable for GitHub Actions. It introduces the following:

Adds following fields to `links.validate.config`:
- `cacheType`:  Specifies type of cache. Can be set to 'SQLite' or 'None'. 'SQLite' creates a database in `.mdoxcache`. 'None' or setting it to empty will ensure no `.mdoxcache` file is created. Will throw error if set to anything else.
- `cacheValidity` which specifies duration till which link in the cache database is valid. Default is `120h` or 5 days.

Also adds following flag in case cache needs to be cleared but there is no filesystem access:
- `--cache.clear` which instructs mdox to drop the entire cache database and start afresh.
