### PR TITLE
Added benchmarks

### DIFF
--- a/pkg/mdformatter/linktransformer/link_bench_test.go
+++ b/pkg/mdformatter/linktransformer/link_bench_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package linktransformer
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bwplotka/mdox/pkg/mdformatter"
+	"github.com/efficientgo/tools/core/pkg/testutil"
+	"github.com/go-kit/kit/log"
+)
+
+var testBuf bytes.Buffer
+
+var (
+	testDoc = `# Hey
+
+This is a test
+	
+# This is a section
+	
+This is a test`
+
+	testDocWithLink = `# Hello
+
+This is a test [link](./doc.md)
+
+This is a test section [link](./doc.md#this-is-a-section)`
+)
+
+func benchLinktransformer(b *testing.B) {
+	tmpDir, err := ioutil.TempDir("", "bench-test")
+	testutil.Ok(b, err)
+	b.Cleanup(func() { testutil.Ok(b, os.RemoveAll(tmpDir)) })
+
+	testutil.Ok(b, os.MkdirAll(filepath.Join(tmpDir, "repo", "docs"), os.ModePerm))
+	testutil.Ok(b, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc.md"), []byte(testDoc), os.ModePerm))
+	testutil.Ok(b, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "links.md"), []byte(testDocWithLink), os.ModePerm))
+	anchorDir := filepath.Join(tmpDir, "repo", "docs")
+	logger := log.NewLogfmtLogger(os.Stderr)
+
+	file, err := os.OpenFile(filepath.Join(tmpDir, "repo", "docs", "links.md"), os.O_RDONLY, 0)
+	testutil.Ok(b, err)
+	defer file.Close()
+
+	f := mdformatter.New(context.Background(), mdformatter.WithLinkTransformer(MustNewValidator(logger, []byte(""), anchorDir)))
+	b.ResetTimer()
+	b.Run("Validator", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			testutil.Ok(b, f.Format(file, &testBuf))
+		}
+	})
+}
+
+func Benchmark_Linktransformer(b *testing.B) { benchLinktransformer(b) }

--- a/pkg/mdformatter/mdformatter_bench_test.go
+++ b/pkg/mdformatter/mdformatter_bench_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package mdformatter
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/efficientgo/tools/core/pkg/testutil"
+)
+
+var testBuf bytes.Buffer
+
+func benchMdformatter(filename string, b *testing.B) {
+	file, err := os.OpenFile(filename, os.O_RDONLY, 0)
+	testutil.Ok(b, err)
+	defer file.Close()
+
+	f := New(context.Background())
+	b.ResetTimer()
+	b.Run(filename, func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			testutil.Ok(b, f.Format(file, &testBuf))
+		}
+	})
+}
+
+func Benchmark_Mdformatter(b *testing.B) { benchMdformatter("testdata/not_formatted.md", b) }

--- a/pkg/mdformatter/mdgen/benchdata/gohelp.md
+++ b/pkg/mdformatter/mdgen/benchdata/gohelp.md
@@ -1,0 +1,15 @@
+# Benchmark test
+
+Codeblock with go test:
+
+```bash mdox-exec="go help tool" mdox-expect-exit-code=2
+Hello
+```
+
+```bash mdox-exec="go --help" mdox-expect-exit-code=2
+Hello
+```
+
+```bash mdox-exec="go --help" mdox-expect-exit-code=2
+Hello
+```

--- a/pkg/mdformatter/mdgen/benchdata/sleep2.md
+++ b/pkg/mdformatter/mdgen/benchdata/sleep2.md
@@ -1,0 +1,15 @@
+# Benchmark test
+
+Codeblock with 2 seconds:
+
+```bash mdox-exec="bash ./benchdata/sleep2.sh"
+Hello
+```
+
+```bash mdox-exec="bash ./benchdata/sleep2.sh"
+Hello
+```
+
+```bash mdox-exec="bash ./benchdata/sleep2.sh"
+Hello
+```

--- a/pkg/mdformatter/mdgen/benchdata/sleep2.sh
+++ b/pkg/mdformatter/mdgen/benchdata/sleep2.sh
@@ -1,0 +1,3 @@
+echo "Hello"
+
+sleep 2

--- a/pkg/mdformatter/mdgen/benchdata/sleep5.md
+++ b/pkg/mdformatter/mdgen/benchdata/sleep5.md
@@ -1,0 +1,15 @@
+# Benchmark test
+
+Codeblock with 5 seconds:
+
+```bash mdox-exec="bash ./benchdata/sleep5.sh"
+Hello
+```
+
+```bash mdox-exec="bash ./benchdata/sleep5.sh"
+Hello
+```
+
+```bash mdox-exec="bash ./benchdata/sleep5.sh"
+Hello
+```

--- a/pkg/mdformatter/mdgen/benchdata/sleep5.sh
+++ b/pkg/mdformatter/mdgen/benchdata/sleep5.sh
@@ -1,0 +1,3 @@
+echo "Hello"
+
+sleep 5

--- a/pkg/mdformatter/mdgen/mdgen_bench_test.go
+++ b/pkg/mdformatter/mdgen/mdgen_bench_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Bartłomiej Płotka @bwplotka
+// Licensed under the Apache License 2.0.
+
+package mdgen
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/bwplotka/mdox/pkg/mdformatter"
+	"github.com/efficientgo/tools/core/pkg/testutil"
+)
+
+var testBuf bytes.Buffer
+
+func benchMdgen(filename string, b *testing.B) {
+	file, err := os.OpenFile(filename, os.O_RDONLY, 0)
+	testutil.Ok(b, err)
+	defer file.Close()
+
+	f := mdformatter.New(context.Background(), mdformatter.WithCodeBlockTransformer(NewCodeBlockTransformer()))
+	b.ResetTimer()
+
+	b.Run(filename, func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			testutil.Ok(b, f.Format(file, &testBuf))
+		}
+	})
+}
+
+func Benchmark_Mdgen_Sleep2(b *testing.B) { benchMdgen("benchdata/sleep2.md", b) }
+
+func Benchmark_Mdgen_Sleep5(b *testing.B) { benchMdgen("benchdata/sleep5.md", b) }
+
+func Benchmark_Mdgen_GoHelp(b *testing.B) { benchMdgen("benchdata/gohelp.md", b) }


### PR DESCRIPTION
This PR adds benchmarks for `mdformatter` and `mdgen`.

Run for mdformatter:
```
go test -run=^$ -bench=. -benchtime 20s -memprofile mem.out -cpuprofile cpu.out -benchmem github.com/bwplotka/mdox/pkg/mdformatter
```
Run for mdgen:
```
go test -run=^$ -bench=. -benchtime 20s -memprofile mem.out -cpuprofile cpu.out -benchmem github.com/bwplotka/mdox/pkg/mdformatter/mdgen 
```