### PR TITLE
Add option to preserve header

### DIFF
--- a/pkg/transform/config.go
+++ b/pkg/transform/config.go
@@ -68,6 +68,8 @@ type TransformationConfig struct {
 	// TODO(bwplotka): Explain ** and * suffixes and ability to specify "invalid" paths like "/../".
 	Path string
 
+	PopHeader bool `yaml:"popHeader"`
+
 	// FrontMatter holds front matter transformations.
 	FrontMatter *MatterConfig `yaml:"frontMatter"`
 

--- a/pkg/transform/config.go
+++ b/pkg/transform/config.go
@@ -68,7 +68,7 @@ type TransformationConfig struct {
 	// TODO(bwplotka): Explain ** and * suffixes and ability to specify "invalid" paths like "/../".
 	Path string
 
-	PopHeader bool `yaml:"popHeader"`
+	PopHeader *bool `yaml:"popHeader"`
 
 	// FrontMatter holds front matter transformations.
 	FrontMatter *MatterConfig `yaml:"frontMatter"`

--- a/pkg/transform/testdata/expected/test3/3/Proposals/README.md
+++ b/pkg/transform/testdata/expected/test3/3/Proposals/README.md
@@ -4,6 +4,8 @@ slug: README.md
 lastmod: 'TODO: Allow testing last mod .Origin.LastMod'
 ---
 
+# Proposals
+
 [RelLink](../_index.md)
 
 [RelLink](../Team/doc.md)

--- a/pkg/transform/testdata/mdox1.yaml
+++ b/pkg/transform/testdata/mdox1.yaml
@@ -8,7 +8,6 @@ gitIgnored: true
 transformations:
   - glob: "README.md"
     path: _index.md
-    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"

--- a/pkg/transform/testdata/mdox1.yaml
+++ b/pkg/transform/testdata/mdox1.yaml
@@ -8,6 +8,7 @@ gitIgnored: true
 transformations:
   - glob: "README.md"
     path: _index.md
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"
@@ -18,6 +19,7 @@ transformations:
             path: "/**"
 
   - glob: "**/README.md"
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"

--- a/pkg/transform/testdata/mdox2.yaml
+++ b/pkg/transform/testdata/mdox2.yaml
@@ -17,6 +17,7 @@ transformations:
 
   - glob: "../test.md"
     path: /_index.md
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"
@@ -27,6 +28,7 @@ transformations:
             path: "/**"
 
   - glob: "doc.md"
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"
@@ -34,6 +36,7 @@ transformations:
 
   - glob: "Team/doc.md"
     path: inner/doc.md
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"
@@ -41,6 +44,7 @@ transformations:
 
   - glob: "**/README.md"
     path: /test1/_index.md
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"

--- a/pkg/transform/testdata/mdox3.yaml
+++ b/pkg/transform/testdata/mdox3.yaml
@@ -8,6 +8,7 @@ gitIgnored: true
 transformations:
   - glob: "README.md"
     path: _index.md
+    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"
@@ -35,6 +36,7 @@ transformations:
 
 
   - glob: "**.md"
+    popHeader: true
     backMatter:
       template: |
         Found a typo, inconsistency or missing information in our docs?

--- a/pkg/transform/testdata/mdox3.yaml
+++ b/pkg/transform/testdata/mdox3.yaml
@@ -8,7 +8,6 @@ gitIgnored: true
 transformations:
   - glob: "README.md"
     path: _index.md
-    popHeader: true
     frontMatter:
       template: |
         title: "{{ .Origin.FirstHeader }}"

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -171,7 +171,19 @@ func (t *transformer) transformFile(path string, info os.FileInfo, err error) er
 			return errors.Errorf("front matter option set on file that after transformation is non-markdown: %v", target)
 		}
 
-		firstHeader, rest, err := getFirstHeader(path, tr.PopHeader)
+		dir, file := filepath.Split(path)
+		// Remove trailing slash after split and check if root file.
+		if dir[:len(dir)-1] == t.c.InputDir && isMDFile(file) && tr.PopHeader == nil {
+			// Default popHeader to true for inputDir root file.
+			tr.PopHeader = func() *bool { b := true; return &b }()
+		}
+
+		// If unset and not root file.
+		if tr.PopHeader == nil {
+			tr.PopHeader = func() *bool { b := false; return &b }()
+		}
+
+		firstHeader, rest, err := getFirstHeader(path, *tr.PopHeader)
 		if err != nil {
 			return errors.Wrap(err, "read first header")
 		}


### PR DESCRIPTION
This PR changes `transform` tranformation config to preserve markdown headers by default while transforming as discussed in 1:1. `popHeader` option may be added to enable removing header. 

Note: Could not find a better explicit way of enabling remove header other than bool option in config (as was mentioned in 1:1). Would a flag instead be preferred?