### PR TITLE
Fix link line number

### DIFF
--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -256,7 +256,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check 404 link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists\n"), os.ModePerm))
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\n"), os.ModePerm))
 		filePath := "/repo/docs/test/invalid-link.md"
 		wdir, err := os.Getwd()
 		testutil.Ok(t, err)
@@ -271,7 +271,9 @@ func TestValidator_TransformDestination(t *testing.T) {
 			MustNewValidator(logger, []byte(""), anchorDir),
 		))
 		testutil.NotOk(t, err)
-		testutil.Equals(t, fmt.Sprintf("%v%v: %v%v:1: \"https://bwplotka.dev/does-not-exists\" not accessible; status code 404: Not Found", tmpDir, filePath, relDirPath, filePath), err.Error())
+		testutil.Equals(t, fmt.Sprintf("%v: 2 errors: "+
+			"%v:1: \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\" not accessible; status code 0: Get \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\": dial tcp: lookup docs.gfoogle.com: no such host; "+
+			"%v:1: \"https://bwplotka.dev/does-not-exists\" not accessible; status code 404: Not Found", tmpDir+filePath, relDirPath+filePath, relDirPath+filePath), err.Error())
 	})
 
 	t.Run("check valid & 404 link with validate config", func(t *testing.T) {

--- a/pkg/mdformatter/transformer.go
+++ b/pkg/mdformatter/transformer.go
@@ -196,7 +196,7 @@ func getLinkLines(source []byte, link []byte, lenfm int) string {
 		lenfm += 2
 	}
 	// Using regex, as two links may have same host but diff params. Same in case of local links.
-	linkRe := regexp.MustCompile(`(^|[^/\-~&=#?@%a-zA-Z0-9])` + string(link) + `($|[^/\-~&=#?@%a-zA-Z0-9])`)
+	linkRe := regexp.MustCompile(`(^|[^/\-~&=#?@%a-zA-Z0-9])` + regexp.QuoteMeta(string(link)) + `($|[^/\-~&=#?@%a-zA-Z0-9])`)
 	for i, line := range sourceLines {
 		if linkRe.Match(line) {
 			// Easier to just return int slice, but then cannot use it in futureKey.


### PR DESCRIPTION
This PR fixes issue where link error line number doesn't show in error for links containing special character.

For e.g. links like, `https://docs.google.com/drawings/d/e/2PACX-1vTfko27YB_3ab7ZL8ODNG5uCcrpqKxhmqaz3lW-yhGN3_oNxkTrqfXmwwlcZjaWf3cGgAJIM4CMwwkEV/pub?w=960&h=720` show the following error,

```
README.md:: "https://docs.google.com/drawings/d/e/2PACX-1vTfko27YB_3ab7ZL8ODNG5uCcrpqKxhmqaz3lW-yhGN3_oNxkTrqfXmwwlcZjaWf3cGgAJIM4CMwwkEV/pub?w=960&h=720" not accessible; status code 400: Bad Request
```