### PR TITLE
Add support for email links

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -288,12 +288,11 @@ func (v *validator) visit(filepath string, dest string, lineNumbers string) {
 	matches := remoteLinkPrefixRe.FindAllStringIndex(dest, 1)
 	if matches == nil {
 		// Check if link is email address.
-		if strings.HasPrefix(dest, "mailto:") {
-			email := strings.Split(dest, "mailto:")
-			if checkEmail(strings.TrimSpace(email[1])) {
+		if email := strings.TrimPrefix(dest, "mailto:"); email != dest {
+			if isValidEmail(email) {
 				return
 			}
-			v.destFutures[k].resultFn = func() error { return errors.New("email not valid " + dest) }
+			v.destFutures[k].resultFn = func() error { return errors.Errorf("provided mailto link is not a valid email, got %v", dest) }
 			return
 		}
 
@@ -315,8 +314,8 @@ func (v *validator) visit(filepath string, dest string, lineNumbers string) {
 	}
 }
 
-// checkEmail checks email structure and domain.
-func checkEmail(email string) bool {
+// isValidEmail checks email structure and domain.
+func isValidEmail(email string) bool {
 	// Check length.
 	if len(email) < 3 && len(email) > 254 {
 		return false

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -286,7 +286,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 			MustNewValidator(logger, []byte(""), anchorDir),
 		))
 		testutil.NotOk(t, err)
-		testutil.Equals(t, fmt.Sprintf("%v: "+"%v:1: email not valid mailto:test@mdox.com", tmpDir+filePath, relDirPath+filePath), err.Error())
+		testutil.Equals(t, fmt.Sprintf("%v: "+"%v:1: provided mailto link is not a valid email, got mailto:test@mdox.com", tmpDir+filePath, relDirPath+filePath), err.Error())
 	})
 
 	t.Run("check 404 link", func(t *testing.T) {

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -254,6 +254,41 @@ func TestValidator_TransformDestination(t *testing.T) {
 			tmpDir+filePath, relDirPath+filePath, tmpDir, relDirPath+filePath, tmpDir, relDirPath+filePath, tmpDir, relDirPath+filePath, tmpDir), err.Error())
 	})
 
+	t.Run("check valid email link", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-email.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("[yolo](mailto:test@yahoo.com)\n"), os.ModePerm))
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		diff, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, []byte(""), anchorDir),
+		))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+	})
+
+	t.Run("check invalid email link", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-email.md")
+		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("[yolo](mailto:test@mdox.com)\n"), os.ModePerm))
+		filePath := "/repo/docs/test/invalid-email.md"
+		wdir, err := os.Getwd()
+		testutil.Ok(t, err)
+		relDirPath, err := filepath.Rel(wdir, tmpDir)
+		testutil.Ok(t, err)
+
+		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
+		testutil.Ok(t, err)
+		testutil.Equals(t, 0, len(diff), diff.String())
+
+		_, err = mdformatter.IsFormatted(context.TODO(), logger, []string{testFile}, mdformatter.WithLinkTransformer(
+			MustNewValidator(logger, []byte(""), anchorDir),
+		))
+		testutil.NotOk(t, err)
+		testutil.Equals(t, fmt.Sprintf("%v: "+"%v:1: email not valid mailto:test@mdox.com", tmpDir+filePath, relDirPath+filePath), err.Error())
+	})
+
 	t.Run("check 404 link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-link.md")
 		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\n"), os.ModePerm))


### PR DESCRIPTION
This PR adds checks for `mailto:` email links like [here](https://github.com/prometheus-operator/prometheus-operator/blame/master/Documentation/user-guides/getting-started.md#L4). It validates email using regex as specified [here](https://www.w3.org/TR/2016/REC-html51-20161101/sec-forms.html#email-state-typeemail) and also checks if email has valid domain using `net.LookupMX`. Fixes #65.