### PR TITLE
Add newline check for `mdox-exec` output

### DIFF
--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -84,7 +84,12 @@ func (t *genCodeBlockTransformer) TransformCodeBlock(ctx mdformatter.SourceConte
 			}
 			return nil, errors.Wrapf(err, "run %v, out: %v", execCmd, b.String())
 		}
-		return b.Bytes(), nil
+		output := b.Bytes()
+		// Add newline to output if not present.
+		if !bytes.HasSuffix(output, []byte("\n")) {
+			output = append(output, []byte("\n")...)
+		}
+		return output, nil
 	}
 
 	panic("should never get here")

--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -20,6 +20,10 @@ const (
 	infoStringKeyExitCode = "mdox-expect-exit-code"
 )
 
+var (
+	newLineChar = []byte("\n")
+)
+
 type genCodeBlockTransformer struct{}
 
 func NewCodeBlockTransformer() *genCodeBlockTransformer {
@@ -86,8 +90,8 @@ func (t *genCodeBlockTransformer) TransformCodeBlock(ctx mdformatter.SourceConte
 		}
 		output := b.Bytes()
 		// Add newline to output if not present.
-		if !bytes.HasSuffix(output, []byte("\n")) {
-			output = append(output, []byte("\n")...)
+		if !bytes.HasSuffix(output, newLineChar) {
+			output = append(output, newLineChar...)
 		}
 		return output, nil
 	}

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -41,3 +41,10 @@ echo "test output3"
 test output2
 newline
 ```
+
+```bash mdox-exec="cat ./testdata/out3.sh"
+#!/usr/bin/env bash
+
+echo "test output3"
+exit 2
+```

--- a/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_not_formatted.md
@@ -40,3 +40,6 @@ abc
 
 ```yaml mdox-exec="bash ./testdata/out2.sh --name=queryfrontend.InMemoryResponseCacheConfig"
 ```
+
+```bash mdox-exec="cat ./testdata/out3.sh"
+```


### PR DESCRIPTION
This PR adds a check to ensure `mdgen` output for a command always has a new line at the end so that there are no surprising formatting issues. Test case added. Fixes #67.