### PR TITLE
Add timeout option to `links.validate.config`

### DIFF
--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -20,6 +21,9 @@ type Config struct {
 	Version int
 
 	Validators []ValidatorConfig `yaml:"validators"`
+	Timeout    string            `yaml:"timeout"`
+
+	timeout time.Duration
 }
 
 type ValidatorConfig struct {
@@ -70,6 +74,14 @@ func ParseConfig(c []byte) (Config, error) {
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
 		return Config{}, errors.Wrapf(err, "parsing YAML content %q", string(c))
+	}
+
+	if cfg.Timeout != "" {
+		var err error
+		cfg.timeout, err = time.ParseDuration(cfg.Timeout)
+		if err != nil {
+			return Config{}, errors.Wrap(err, "parsing timeout duration")
+		}
 	}
 
 	if len(cfg.Validators) <= 0 {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -162,6 +162,9 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 	// Set very soft limits.
 	// E.g github has 50-5000 https://docs.github.com/en/free-pro-team@latest/rest/reference/rate-limit limit depending
 	// on api (only search is below 100).
+	if config.Timeout != "" {
+		v.c.SetRequestTimeout(config.timeout)
+	}
 	if err := v.c.Limit(&colly.LimitRule{
 		DomainGlob:  "*",
 		Parallelism: 100,


### PR DESCRIPTION
This PR adds a `timeout` option to `links.validate.config` to enable setting custom request timeouts for colly collector. Need feedback on how to test.🙂   
Fixes #64.