### PR TITLE
Add `Origin.Path` to transform template

### DIFF
--- a/pkg/transform/testdata/expected/test3/3/Team/doc.md
+++ b/pkg/transform/testdata/expected/test3/3/Team/doc.md
@@ -8,4 +8,4 @@
 
 ---
 
-Found a typo, inconsistency or missing information in our docs? Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/docs/doc.md) :heart:
+Found a typo, inconsistency or missing information in our docs? Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/testdata/testproj/Team/doc.md) :heart:

--- a/pkg/transform/testdata/mdox3.yaml
+++ b/pkg/transform/testdata/mdox3.yaml
@@ -39,7 +39,7 @@ transformations:
     backMatter:
       template: |
         Found a typo, inconsistency or missing information in our docs?
-        Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/docs/{{ .Origin.Filename }}) :heart:
+        Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/{{ .Origin.Path }}) :heart:
 
 
   - glob: "**"

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -194,6 +194,15 @@ func (t *transformer) transformFile(path string, info os.FileInfo, err error) er
 			}
 		}
 
+		wd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "get working dir for Path")
+		}
+		originPath, err := filepath.Rel(wd, path)
+		if err != nil {
+			return errors.Wrap(err, "rel path to working dir")
+		}
+
 		_, originFilename := filepath.Split(path)
 		_, targetFilename := filepath.Split(target)
 		opts = append(opts, mdformatter.WithFrontMatterTransformer(&frontMatterTransformer{
@@ -202,6 +211,7 @@ func (t *transformer) transformFile(path string, info os.FileInfo, err error) er
 			origin: MatterOrigin{
 				Filename:    originFilename,
 				FirstHeader: firstHeader,
+				Path:        originPath,
 				LastMod:     info.ModTime().String(),
 			},
 			target: MatterTarget{
@@ -214,12 +224,23 @@ func (t *transformer) transformFile(path string, info os.FileInfo, err error) er
 		if !isMDFile(target) {
 			return errors.Errorf("back matter option set on file that after transformation is non-markdown: %v", target)
 		}
+
+		wd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "get working dir for Path")
+		}
+		originPath, err := filepath.Rel(wd, path)
+		if err != nil {
+			return errors.Wrap(err, "rel path to working dir")
+		}
+
 		_, originFilename := filepath.Split(path)
 		_, targetFilename := filepath.Split(target)
 		opts = append(opts, mdformatter.WithBackMatterTransformer(&backMatterTransformer{
 			b: tr.BackMatter,
 			origin: MatterOrigin{
 				Filename: originFilename,
+				Path:     originPath,
 				LastMod:  info.ModTime().String(),
 			},
 			target: MatterTarget{
@@ -328,6 +349,7 @@ type MatterOrigin struct {
 	Filename    string
 	FirstHeader string
 	LastMod     string
+	Path        string
 }
 
 type MatterTarget struct {


### PR DESCRIPTION
This PR adds `Origin.Path` to front/backmatter templates. This is useful in case of constructing links that require paths such as GitHub edit links in path matter and makes YAML DRY-er, for example,
```
    backMatter:
      template: |
        Found a typo, inconsistency or missing information in our docs?
        Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/{{ .Origin.Path }}) :heart:
```
Test case also added.