### PR TITLE
Update README.md with examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,12 @@ deps: ## Ensures fresh go.mod and go.sum.
 .PHONY: docs
 docs: build ## Generates config snippets and doc formatting.
 	@echo ">> generating docs $(PATH)"
-	@PATH=$(GOBIN) mdox fmt -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) *.md
+	PATH=${PATH}:$(GOBIN) mdox fmt -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) *.md
 
 .PHONY: check-docs
 check-docs: build ## Checks docs for discrepancies in formatting and links.
 	@echo ">> checking formatting and links $(PATH)"
-	@PATH=$(GOBIN) mdox fmt --check -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) *.md
+	PATH=${PATH}:$(GOBIN) mdox fmt --check -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) *.md
 
 .PHONY: format
 format: ## Formats Go code.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/bwplotka/mdox) [![Latest Release](https://img.shields.io/github/release/bwplotka/mdox.svg?style=flat-square)](https://github.com/bwplotka/mdox/releases/latest) [![CI](https://github.com/bwplotka/mdox/workflows/go/badge.svg)](https://github.com/bwplotka/mdox/actions?query=workflow%3Ago) [![Go Report Card](https://goreportcard.com/badge/github.com/bwplotka/mdox)](https://goreportcard.com/report/github.com/bwplotka/mdox)
 
-`mdox` (spelled as `md docs`) is a CLI for maintaining automated, high quality project documentation and website leveraging [Github Flavored Markdown](https://github.github.com/gfm/) and git.
+`mdox` (spelled as `md docs`) is a CLI for maintaining automated, high-quality project documentation and website leveraging [Github Flavored Markdown](https://github.github.com/gfm/) and git.
 
-This project can be used both as CLI as well as library.
+This project can be used both as CLI as well as a library.
 
 ## Goals
 
-Allow projects to have self-updating up-to-date documentation available in both markdown (e.g readable from GitHub) and static HTML. Hosted in the same repository as code and integrated with Pull Requests CI, hosting CD and code generation.
+Allow projects to have self-updating up-to-date documentation available in both markdown (e.g readable from GitHub) and static HTML. Hosted in the same repository as code and integrated with Pull Requests CI, hosting CD, and code generation.
 
 ## Features
 
@@ -16,17 +16,19 @@ Allow projects to have self-updating up-to-date documentation available in both 
 * Auto generation of code block content based on `mdox-exec` directives (see [#code-generation](#code-generation)). Useful for:
   * Generating help output from CLI --help
   * Generating example YAML from Go configuration struct (+comments)
-* Robust and fast relative and remote link checking.
+* Robust and fast relative and remote link checking. (see [#link-validation-configuration](#link-validation-configuration))
 * Website integration:
   * "Localizing" links to relative docs if specified (useful for multi-domain websites or multi-version doc).
     * This allows smooth integration with static document websites like [Docusaurus](https://docusaurus.io/) or [hugo](https://gohugo.io) based themes!
-  * Flexible pre-processing allowing easy to use GitHub experience as well as website.
+  * Flexible pre-processing allowing easy to use GitHub experience as well as website. (see [#transform-usage](#transformation))
 
 ## Usage
 
+### Formatting and Link Checking
+
 Just run `mdox fmt` and pass markdown files (or glob matching those).
 
-For example this README is formatted by the CI on every PR using [`mdox fmt -l *.md` command](https://github.com/bwplotka/mdox/blob/9e183714070f464b1ef089da3df8048aff1abeda/Makefile#L59).
+For example, this README is formatted by the CI on every PR using [`mdox fmt -l *.md` command](https://github.com/bwplotka/mdox/blob/9e183714070f464b1ef089da3df8048aff1abeda/Makefile#L59).
 
 ```bash mdox-exec="mdox fmt --help"
 usage: mdox fmt [<flags>] <files>...
@@ -75,7 +77,7 @@ Args:
 
 ```
 
-### Code Generation
+#### Code Generation
 
 It's not uncommon that documentation is explaining code or configuration snippets. One of the challenges of such documentation is keeping it up to date. This is where `mdox` code block directives comes handy! To ensure mdox will auto update code snippet add `mdox-exec="<whatever command you want take output from>"` after language directive on code block.
 
@@ -93,7 +95,137 @@ This also enables auto updating snippets of code in code blocks using tools like
 ...
 ```
 
+Some commands might have non-zero exit codes. mdox will fail commands in such cases(otherwise errors might get formatted into markdown) but the expected exit code can also be passed as a code block directive! For example, below code block executes `go --help` which has 2 as its exit code,
+
+```markdown
+```go mdox-exec="go --help" mdox-expect-exit-code=2
+...
+```
+
 You can disable this feature by specifying `--code.disable-directives`
+
+#### Link Validation Configuration
+
+By default, mdox checks all links (both relative and remote) in passed markdown files! However, in some cases, link checks might fail even when links are working, such as with rate limiting, Cloudflare protections, or something else(like localhost links in docs).
+
+This might lead to failed CI checks which aren't desirable. So, you can use the `links.validate.config-file` flag to pass in YAML configuration file for selective link checking using special validators and link regexes.
+
+For example,
+
+```yaml mdox-exec="cat examples/.mdox.validate.yaml"
+version: 1
+
+validators:
+  - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
+    type: 'githubPullsIssues'
+
+  - regex: 'localhost'
+    type: 'ignore'
+
+  - regex: 'thanos\.io'
+    type: 'roundtrip'
+
+```
+
+As seen above, mdox supports passing an array of link validators with types and regexes. There are three types of validators,
+
+* `ignore`: This type of validator makes sure that `mdox` does not check links with provided regex. This is the most common use case.
+* `githubPullsIssues`: This is a smart validator which only accepts a specific type of regex of the form `(^http[s]?:\/\/)(www\.)?(github\.com\/){ORG}\/{REPO}(\/pull\/|\/issues\/)`. It performs smart validation on GitHub PR and issues links, by fetching GitHub API to get the latest pull/issue number and matching regex. This makes sure that mdox doesn't get rate limited by GitHub, even when checking a large number of GitHub links(which is pretty common in documentation)!
+* `roundtrip`: All links are checked with the roundtrip validator by default(no need for including into config explicitly) which means that each link is visited and fails if http status code is not 200(even after retries).
+
+Relative link checking *is not* affected by this configuration, as it is expected that such links will work.
+
+YAML can be passed in directly as well using `links.validate.config` flag! For more details [go.dev reference](https://pkg.go.dev/github.com/bwplotka/mdox) or [Go struct](https://github.com/bwplotka/mdox/blob/main/pkg/mdformatter/linktransformer/config.go).
+
+### Transformation
+
+mdox allows various types of markdown file transformation which are useful for website pre-processing and is often required when using static site generators like Hugo. It helps in generating front/backmatter, renaming and moving files, and converts links to work on websites.
+
+Just run `mdox transform --config-file=.mdox.yaml` and pass in YAML configuration.
+
+```bash mdox-exec="mdox transform --help"
+usage: mdox transform [<flags>]
+
+Transform markdown files in various ways. For example pre process markdown files
+to allow it for use for popular static HTML websites based on markdown source
+code and front matter options.
+
+Flags:
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --version                  Show application version.
+      --log.level=info           Log filtering level.
+      --log.format=clilog        Log format to use.
+      --config-file=<file-path>  Path to Path to the YAML file with spec defined
+                                 in
+                                 github.com/bwplotka/mdox/pkg/transform.Config
+      --config=<content>         Alternative to 'config-file' flag (mutually
+                                 exclusive). Content of Path to the YAML file
+                                 with spec defined in
+                                 github.com/bwplotka/mdox/pkg/transform.Config
+
+```
+
+For example,
+
+```yaml mdox-exec="cat examples/.mdox.yaml"
+version: 1
+
+inputDir: "docs"
+outputDir: "website/docs-pre-processed/tip"
+extraInputGlobs:
+  - "CHANGELOG.md"
+  - "static"
+
+gitIgnored: true
+localLinksStyle:
+  hugo:
+    indexFileName: "_index.md"
+
+transformations:
+
+  - glob: "../CHANGELOG.md"
+    path: /thanos/CHANGELOG.md
+    popHeader: true
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        type: docs
+        lastmod: "{{ .Origin.LastMod }}"
+    backMatter:
+      template: |
+        Found a typo, inconsistency or missing information in our docs?
+        Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/{{ .Origin.Filename }}) :heart:
+
+  - glob: "getting-started.md"
+    path: /thanos/getting-started.md
+    frontMatter:
+      template: |
+        type: docs
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        slug: "{{ .Target.FileName }}"
+
+  - glob: "../static/**"
+    path: /favicons/**
+```
+
+As seen above,
+
+* `inputDir`: It's a relative (to PWD) path that assumes input directory for markdown files and assets.
+* `outputDir`: It's a relative (to PWD) output directory where you can expect all files to land in. Typically that can be a `content` dir which Hugo uses as an input.
+* `extraInputGlobs`: It allows you to bring files from outside of `inputDir`.
+* `gitIgnored`: It specifies whether `outputDir` should be git-ignored.
+* `localLinksStyle`: It sets the linking style to be applied. If empty, mdox assumes default style.
+
+* `transformation`: Array of transformations to apply for files in `inputDir` and `extraInputGlobs`. This consists of,
+  * `glob`: It is matched against the relative path of the file in the `inputDir` using https://github.com/gobwas/glob.
+  * `path`: It is an optional different path for the file to be moved into. If not specified, the file will be moved to the exact same position as it is in `inputDir`.
+  * `popHeader`: If set to true, it pops the first header of md file. True by default for files in the root of `inputDir`
+  * `frontMatter`: Optional template for constructing frontmatter of markdown file.
+  * `backMatter`: Optional template for constructing backmatter of markdown file(content appended to end like edit links)
+
+YAML can be passed in directly as well using `--config` flag! For more details [go.dev reference](https://pkg.go.dev/github.com/bwplotka/mdox) or [Go struct](https://github.com/bwplotka/mdox/blob/main/pkg/transform/config.go).
 
 ### Installing
 
@@ -112,9 +244,14 @@ or via [bingo](https://github.com/bwplotka/bingo) if want to pin it:
 bingo get -u github.com/bwplotka/mdox
 ```
 
-### Production Usage
+## Production Usage
 
-* [Thanos](https://github.com/bwplotka/thanos) (TBD)
+* [Thanos](https://github.com/bwplotka/thanos)
+* [Observatorium](https://github.com/observatorium/observatorium)
+* [RedHat Observability Group Handbook](https://github.com/rhobs/handbook)
+* [Bingo](https://github.com/bwplotka/bingo)
+* [effiecientgo/tools](https://github.com/efficientgo/tools)
+* [effiecientgo/e2e](https://github.com/efficientgo/e2e)
 
 ## Contributing
 

--- a/examples/.mdox.validate.yaml
+++ b/examples/.mdox.validate.yaml
@@ -1,0 +1,12 @@
+version: 1
+
+validators:
+  - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
+    type: 'githubPullsIssues'
+
+  - regex: 'localhost'
+    type: 'ignore'
+
+  - regex: 'thanos\.io'
+    type: 'roundtrip'
+

--- a/examples/.mdox.yaml
+++ b/examples/.mdox.yaml
@@ -1,0 +1,39 @@
+version: 1
+
+inputDir: "docs"
+outputDir: "website/docs-pre-processed/tip"
+extraInputGlobs:
+  - "CHANGELOG.md"
+  - "static"
+
+gitIgnored: true
+localLinksStyle:
+  hugo:
+    indexFileName: "_index.md"
+
+transformations:
+
+  - glob: "../CHANGELOG.md"
+    path: /thanos/CHANGELOG.md
+    popHeader: true
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        type: docs
+        lastmod: "{{ .Origin.LastMod }}"
+    backMatter:
+      template: |
+        Found a typo, inconsistency or missing information in our docs?
+        Help us to improve [Thanos](https://thanos.io) documentation by proposing a fix [on GitHub here](https://github.com/thanos-io/thanos/edit/main/{{ .Origin.Filename }}) :heart:
+
+  - glob: "getting-started.md"
+    path: /thanos/getting-started.md
+    frontMatter:
+      template: |
+        type: docs
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        slug: "{{ .Target.FileName }}"
+
+  - glob: "../static/**"
+    path: /favicons/**


### PR DESCRIPTION
This PR updates `README.md` with current features that mdox supports now, along with sample configs for transform and link validators. Preview how it looks [here](https://github.com/saswatamcode/mdox/tree/add-docs).