### PR TITLE
Add `soft-wraps` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Flags:
       --log.format=clilog        Log format to use.
       --check                    If true, fmt will not modify the given files,
                                  instead it will fail if files needs formatting
+      --soft-wraps               If true, fmt will preserve soft line breaks for
+                                 given files
       --code.disable-directives  If false, fmt will parse custom fenced code
                                  directives prefixed with 'mdox-gen' to
                                  autogenerate code snippets. For example:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bwplotka/mdox
 go 1.15
 
 require (
-	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210622145915-e6bf3dcd02de
+	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c
 	github.com/antchfx/xmlquery v1.3.4 // indirect
 	github.com/charmbracelet/glamour v0.3.0
 	github.com/efficientgo/tools/core v0.0.0-20210609125236-d73259166f20

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190418212003-6ac0b49e7197/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210622145915-e6bf3dcd02de h1:VpixUG1dDCCTtgTdSPoxuyzwDqLLt1dXZ5v4Ur0c9PY=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210622145915-e6bf3dcd02de/go.mod h1:LFJueuHZej/Z7Xhqh/XgClfkDjZiiEBOLVTt1Duq1r0=
+github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c h1:rnouiLtDKeaWKnxRViK454oCI8jkhWv5fItCvZ9nJOU=
+github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c/go.mod h1:LFJueuHZej/Z7Xhqh/XgClfkDjZiiEBOLVTt1Duq1r0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func registerFmt(_ context.Context, app *extkingpin.App) {
 	cmd := app.Command("fmt", "Formats in-place given markdown files uniformly following GFM (Github Flavored Markdown: https://github.github.com/gfm/). Example: mdox fmt *.md")
 	files := cmd.Arg("files", "Markdown file(s) to process.").Required().ExistingFiles()
 	checkOnly := cmd.Flag("check", "If true, fmt will not modify the given files, instead it will fail if files needs formatting").Bool()
+	softWraps := cmd.Flag("soft-wraps", "If true, fmt will preserve soft line breaks for given files").Bool()
 
 	disableGenCodeBlocksDirectives := cmd.Flag("code.disable-directives", `If false, fmt will parse custom fenced code directives prefixed with 'mdox-gen' to autogenerate code snippets. For example:
 	`+"```"+`<lang> mdox-exec="<executable + arguments>"
@@ -134,6 +135,9 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		var opts []mdformatter.Option
 		if !*disableGenCodeBlocksDirectives {
 			opts = append(opts, mdformatter.WithCodeBlockTransformer(mdgen.NewCodeBlockTransformer()))
+		}
+		if *softWraps {
+			opts = append(opts, mdformatter.WithSoftWraps())
 		}
 		if len(*files) == 0 {
 			return errors.New("no files to format")

--- a/pkg/mdformatter/mdformatter.go
+++ b/pkg/mdformatter/mdformatter.go
@@ -61,6 +61,8 @@ type Formatter struct {
 	bm   BackMatterTransformer
 	link LinkTransformer
 	cb   CodeBlockTransformer
+
+	softWraps bool
 }
 
 // Option is a functional option type for Formatter objects.
@@ -91,6 +93,13 @@ func WithLinkTransformer(l LinkTransformer) Option {
 func WithCodeBlockTransformer(cb CodeBlockTransformer) Option {
 	return func(m *Formatter) {
 		m.cb = cb
+	}
+}
+
+// WithCodeBlockTransformer allows you to override default softWrap.
+func WithSoftWraps() Option {
+	return func(m *Formatter) {
+		m.softWraps = true
 	}
 }
 
@@ -345,8 +354,12 @@ func (f *Formatter) Format(file *os.File, out io.Writer) error {
 	// Hack: run Convert two times to ensure deterministic whitespace alignment.
 	// This also immediately show transformers which are not working well together etc.
 	tmp := bytes.Buffer{}
+	renderer := markdown.NewRenderer()
+	if f.softWraps {
+		renderer.AddMarkdownOptions(markdown.WithSoftWraps())
+	}
 	tr := &transformer{
-		wrapped:   markdown.NewRenderer(),
+		wrapped:   renderer,
 		sourceCtx: sourceCtx,
 		link:      f.link, cb: f.cb,
 		frontMatterLen: len(frontMatter),
@@ -364,7 +377,7 @@ func (f *Formatter) Format(file *os.File, out io.Writer) error {
 	if err := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
 		goldmark.WithParserOptions(parser.WithAttribute() /* Enable # headers {#custom-ids} */, parser.WithHeadingAttribute()),
-		goldmark.WithRenderer(markdown.NewRenderer()), // No transforming for second phase.
+		goldmark.WithRenderer(renderer), // No transforming for second phase.
 	).Convert(tmp.Bytes(), out); err != nil {
 		return errors.Wrapf(err, "second formatting phase for %v", file.Name())
 	}

--- a/pkg/mdformatter/testdata/formatted_softwraps.md
+++ b/pkg/mdformatter/testdata/formatted_softwraps.md
@@ -1,0 +1,28 @@
+# Quick Tutorial
+
+Feel free to check the free, in-browser interactive
+tutorial [as Katacoda Thanos Course](https://katacoda.com/bwplotka/courses/thanos)
+We will be progressively updating our
+Katacoda Course with more scenarios.
+
+On top of this feel free to go through our tutorial presented here:
+
+Yolo link https://thanos.io/some
+Yolo email something@gmail.com
+
+* [ ] task
+  * [X] task
+
+### Prometheus
+
+The `thanos rule` command evaluates Prometheus recording and alerting rules
+against chosen query API via repeated `--query` (or FileSD via `--query.sd`).
+If more than one query is passed, round robin balancing is performed.
+
+Rule results are written back to disk in the Prometheus 2.0 storage format.
+Rule nodes at the same time participate in the system as source store nodes,
+which means that they expose StoreAPI and *upload* their generated TSDB blocks
+to an object store.
+
+You can think of Rule as a simplified Prometheus that does not require
+a sidecar and does not scrape and do PromQL evaluation (no QueryAPI).

--- a/pkg/mdformatter/testdata/not_formatted_softwraps.md
+++ b/pkg/mdformatter/testdata/not_formatted_softwraps.md
@@ -1,0 +1,27 @@
+# Quick Tutorial
+
+Feel free to check the free, in-browser interactive 
+tutorial [as Katacoda Thanos Course](https://katacoda.com/bwplotka/courses/thanos)
+We will be progressively updating our 
+Katacoda Course with more scenarios.
+
+On top of this feel free to go through our tutorial presented here:
+
+Yolo link https://thanos.io/some
+Yolo email something@gmail.com
+
+* [ ] task
+  * [x] task
+### Prometheus
+
+The `thanos rule` command evaluates Prometheus recording and alerting rules
+against chosen query API via repeated `--query` (or FileSD via `--query.sd`).
+If more than one query is passed, round robin balancing is performed.
+
+Rule results are written back to disk in the Prometheus 2.0 storage format.
+Rule nodes at the same time participate in the system as source store nodes,
+which means that they expose StoreAPI and *upload* their generated TSDB blocks
+to an object store.
+
+You can think of Rule as a simplified Prometheus that does not require
+a sidecar and does not scrape and do PromQL evaluation (no QueryAPI).

--- a/pkg/mdformatter/testdata/not_formatted_softwraps.md.diff
+++ b/pkg/mdformatter/testdata/not_formatted_softwraps.md.diff
@@ -1,0 +1,23 @@
+--- testdata/not_formatted_softwraps.md
++++ testdata/not_formatted_softwraps.md (formatted)
+@@ -0,2 +0,2 @@
+ # Quick Tutorial
+
+-Feel free to check the free, in-browser interactive 
++Feel free to check the free, in-browser interactive
+ tutorial [as Katacoda Thanos Course](https://katacoda.com/bwplotka/courses/thanos)
+-We will be progressively updating our 
++We will be progressively updating our
+ Katacoda Course with more scenarios.
+
+ On top of this feel free to go through our tutorial presented here:
+@@ -10,1 +10,2 @@
+ Yolo email something@gmail.com
+
+ * [ ] task
++  * [X] task
+-  * [x] task
++
+ ### Prometheus
+
+ The `thanos rule` command evaluates Prometheus recording and alerting rules


### PR DESCRIPTION
This PR adds the `soft-wraps`  fmt flag for preserving soft line breaks while formatting in mdox.
Added via [Kunde21/markdownfmt#36](https://github.com/Kunde21/markdownfmt/pull/36). Use case in [prometheus-operator#4196](https://github.com/prometheus-operator/prometheus-operator/pull/4196).