### PR TITLE
Add retry for 0 StatusCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 * [#71](https://github.com/bwplotka/mdox/pull/71) Add `Origin.Path` to transform template
 * [#75](https://github.com/bwplotka/mdox/pull/75) Add `soft-wraps` flag to preserve soft line breaks
 * [#76](https://github.com/bwplotka/mdox/pull/76) Add `linkPrefixForNonMarkdownResources` to transform config
+* [#78](https://github.com/bwplotka/mdox/pull/78) Add retry for 0 StatusCode
 
 ### Fixed
 

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -284,7 +284,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 				break
 			}
 			v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(err, "%q rate limited even after retry; status code %v", response.Request.URL.String(), response.StatusCode)
-		case http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusServiceUnavailable:
+		case http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusServiceUnavailable, 0:
 			if retries > 0 {
 				break
 			}

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -284,6 +284,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 				break
 			}
 			v.remoteLinks[response.Ctx.Get(originalURLKey)] = errors.Wrapf(err, "%q rate limited even after retry; status code %v", response.Request.URL.String(), response.StatusCode)
+		// 0 StatusCode means error on call side.
 		case http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusServiceUnavailable, 0:
 			if retries > 0 {
 				break

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -307,7 +307,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		))
 		testutil.NotOk(t, err)
 		testutil.Equals(t, fmt.Sprintf("%v: 2 errors: "+
-			"%v:1: \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\" not accessible; status code 0: Get \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\": dial tcp: lookup docs.gfoogle.com: no such host; "+
+			"%v:1: \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\" not accessible even after retry; status code 0: Get \"https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\": dial tcp: lookup docs.gfoogle.com: no such host; "+
 			"%v:1: \"https://bwplotka.dev/does-not-exists\" not accessible; status code 404: Not Found", tmpDir+filePath, relDirPath+filePath, relDirPath+filePath), err.Error())
 	})
 


### PR DESCRIPTION
This PR adds link retries for 0 status code. As seen in runs in Thanos (for example [here](https://github.com/thanos-io/thanos/runs/3368924522)), mdox errors out if there is status code 0. It isn't [defined](https://pkg.go.dev/net/http#pkg-constants) but generally occurs when the request is aborted for some reason or the host doesn't exist. 
Retrying once might help mitigate this and reduce the annoyance. 