### PR TITLE
Allow quotes in first header

### DIFF
--- a/pkg/transform/testdata/expected/test1/1/Team/doc.md
+++ b/pkg/transform/testdata/expected/test1/1/Team/doc.md
@@ -1,4 +1,4 @@
-# Some Doc
+# Some Doc ("Some Doc")
 
 [RelLink](#some-doc)
 

--- a/pkg/transform/testdata/expected/test2/2/Team/inner/doc.md
+++ b/pkg/transform/testdata/expected/test2/2/Team/inner/doc.md
@@ -1,6 +1,6 @@
 ---
 yolo: yolo
-title: Some Doc
+title: Some Doc ('Some Doc')
 slug: doc.md
 ---
 

--- a/pkg/transform/testdata/expected/test3/3/Team/doc.md
+++ b/pkg/transform/testdata/expected/test3/3/Team/doc.md
@@ -1,4 +1,4 @@
-# Some Doc
+# Some Doc ("Some Doc")
 
 [RelLink](#some-doc)
 

--- a/pkg/transform/testdata/expected/test4/4/Team/inner/doc.md
+++ b/pkg/transform/testdata/expected/test4/4/Team/inner/doc.md
@@ -1,6 +1,6 @@
 ---
 yolo: yolo
-title: Some Doc
+title: Some Doc ('Some Doc')
 slug: doc.md
 ---
 

--- a/pkg/transform/testdata/testproj/Team/doc.md
+++ b/pkg/transform/testdata/testproj/Team/doc.md
@@ -1,4 +1,4 @@
-# Some Doc
+# Some Doc ("Some Doc")
 
 [RelLink](#some-doc)
 

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -496,6 +496,7 @@ func getFirstHeader(path string, popHeader bool) (_ string, rest []byte, err err
 	for scanner.Scan() {
 		text := scanner.Text()
 		if strings.HasPrefix(text, "#") {
+			text = strings.Replace(text, `"`, `'`, -1)
 			if !popHeader {
 				return strings.TrimPrefix(text, "# "), rest, scanner.Err()
 			}


### PR DESCRIPTION
This PR fixes issue where if the first header has double quotes, results in an unexpected error.
It changes double quotes into single quotes, so that valid frontmatter YAML can be generated.

Thus, first header like `# Telemetry ("Telemeter")` or `# Telemetry ('Telemeter')` will generate.
```yaml
title: Telemetry ('Telemeter')
```

Fixes #83.