### PR TITLE
Try to avoid intermittent errors when checking links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Flags:
       --version                  Show application version.
       --log.level=info           Log filtering level.
       --log.format=clilog        Log format to use.
-      --profiles.path=PROFILES.PATH
+      --profiles.path=PROFILES.PATH  
                                  Path to directory where CPU and heap profiles
                                  will be saved; If empty, no profiling will be
                                  enabled.
-      --metrics.path=METRICS.PATH
+      --metrics.path=METRICS.PATH  
                                  Path to directory where metrics are saved in
                                  OpenMetrics format; If empty, no metrics will
                                  be saved.
@@ -58,26 +58,26 @@ Flags:
       --code.disable-directives  If false, fmt will parse custom fenced code
                                  directives prefixed with 'mdox-gen' to
                                  autogenerate code snippets. For example:
-
+                                 
                                    ```<lang> mdox-exec="<executable + arguments>"
-
+                                 
                                  This directive runs executable with arguments
                                  and put its stderr and stdout output inside
                                  code block content, replacing existing one.
       --anchor-dir=ANCHOR-DIR    Anchor directory for all transformers. PWD is
                                  used if flag is not specified.
-      --links.localize.address-regex=LINKS.LOCALIZE.ADDRESS-REGEX
+      --links.localize.address-regex=LINKS.LOCALIZE.ADDRESS-REGEX  
                                  If specified, all HTTP(s) links that target a
                                  domain and path matching given regexp will be
                                  transformed to relative to anchor dir path (if
                                  exists).Absolute path links will be converted
                                  to relative links to anchor dir as well.
   -l, --links.validate           If true, all links will be validated
-      --links.validate.config-file=<file-path>
+      --links.validate.config-file=<file-path>  
                                  Path to YAML file for skipping link check, with
                                  spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
-      --links.validate.config=<content>
+      --links.validate.config=<content>  
                                  Alternative to 'links.validate.config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
@@ -125,20 +125,20 @@ For example,
 
 ```yaml mdox-exec="cat examples/.mdox.validate.yaml"
 version: 1
-timeout: "1m"
+timeout: '1m'
 parallelism: 100
 host_max_conns: 2
-random_delay: "1s"
+random_delay: '1s'
 
 validators:
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
-    type: "githubPullsIssues"
+    type: 'githubPullsIssues'
 
-  - regex: "localhost"
-    type: "ignore"
+  - regex: 'localhost'
+    type: 'ignore'
 
   - regex: 'thanos\.io'
-    type: "roundtrip"
+    type: 'roundtrip'
 ```
 
 As seen above, mdox supports validate configuration supports a few parameters and passing an array of link validators with types and regexes. The supported configuration parameters are:
@@ -187,11 +187,11 @@ Flags:
       --version                  Show application version.
       --log.level=info           Log filtering level.
       --log.format=clilog        Log format to use.
-      --profiles.path=PROFILES.PATH
+      --profiles.path=PROFILES.PATH  
                                  Path to directory where CPU and heap profiles
                                  will be saved; If empty, no profiling will be
                                  enabled.
-      --metrics.path=METRICS.PATH
+      --metrics.path=METRICS.PATH  
                                  Path to directory where metrics are saved in
                                  OpenMetrics format; If empty, no metrics will
                                  be saved.

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Flags:
       --version                  Show application version.
       --log.level=info           Log filtering level.
       --log.format=clilog        Log format to use.
-      --profiles.path=PROFILES.PATH  
+      --profiles.path=PROFILES.PATH
                                  Path to directory where CPU and heap profiles
                                  will be saved; If empty, no profiling will be
                                  enabled.
-      --metrics.path=METRICS.PATH  
+      --metrics.path=METRICS.PATH
                                  Path to directory where metrics are saved in
                                  OpenMetrics format; If empty, no metrics will
                                  be saved.
@@ -58,26 +58,26 @@ Flags:
       --code.disable-directives  If false, fmt will parse custom fenced code
                                  directives prefixed with 'mdox-gen' to
                                  autogenerate code snippets. For example:
-                                 
+
                                    ```<lang> mdox-exec="<executable + arguments>"
-                                 
+
                                  This directive runs executable with arguments
                                  and put its stderr and stdout output inside
                                  code block content, replacing existing one.
       --anchor-dir=ANCHOR-DIR    Anchor directory for all transformers. PWD is
                                  used if flag is not specified.
-      --links.localize.address-regex=LINKS.LOCALIZE.ADDRESS-REGEX  
+      --links.localize.address-regex=LINKS.LOCALIZE.ADDRESS-REGEX
                                  If specified, all HTTP(s) links that target a
                                  domain and path matching given regexp will be
                                  transformed to relative to anchor dir path (if
                                  exists).Absolute path links will be converted
                                  to relative links to anchor dir as well.
   -l, --links.validate           If true, all links will be validated
-      --links.validate.config-file=<file-path>  
+      --links.validate.config-file=<file-path>
                                  Path to YAML file for skipping link check, with
                                  spec defined in
                                  github.com/bwplotka/mdox/pkg/linktransformer.ValidatorConfig
-      --links.validate.config=<content>  
+      --links.validate.config=<content>
                                  Alternative to 'links.validate.config-file'
                                  flag (mutually exclusive). Content of YAML file
                                  for skipping link check, with spec defined in
@@ -143,10 +143,10 @@ validators:
 
 As seen above, mdox supports validate configuration supports a few parameters and passing an array of link validators with types and regexes. The supported configuration parameters are:
 
-* `timeout`: The HTTP client's timeout.
-* `parallelism`: The maximum amount of concurrent HTTP requests.
-* `host_max_conns`: The maximum amount of HTTP connections open per host.
-* `random_delay`: A random delay between 0 and this value is added between requests. It takes values like "500ms", "1s", "1m", or "1m30s".
+* `timeout`: The HTTP client's timeout. Defaults to "10s".
+* `parallelism`: The maximum amount of concurrent HTTP requests. Defaults to 100.
+* `host_max_conns`: The maximum amount of HTTP connections open per host. Defaults to 2.
+* `random_delay`: A random delay between 0 and this value is added between requests. It takes values like "500ms", "1s", "1m", or "1m30s". Defaults to no delay.
 
 There are three types of validators:
 
@@ -187,11 +187,11 @@ Flags:
       --version                  Show application version.
       --log.level=info           Log filtering level.
       --log.format=clilog        Log format to use.
-      --profiles.path=PROFILES.PATH  
+      --profiles.path=PROFILES.PATH
                                  Path to directory where CPU and heap profiles
                                  will be saved; If empty, no profiling will be
                                  enabled.
-      --metrics.path=METRICS.PATH  
+      --metrics.path=METRICS.PATH
                                  Path to directory where metrics are saved in
                                  OpenMetrics format; If empty, no metrics will
                                  be saved.

--- a/README.md
+++ b/README.md
@@ -125,20 +125,30 @@ For example,
 
 ```yaml mdox-exec="cat examples/.mdox.validate.yaml"
 version: 1
+timeout: "1m"
+parallelism: 100
+host_max_conns: 2
+random_delay: "1s"
 
 validators:
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
-    type: 'githubPullsIssues'
+    type: "githubPullsIssues"
 
-  - regex: 'localhost'
-    type: 'ignore'
+  - regex: "localhost"
+    type: "ignore"
 
   - regex: 'thanos\.io'
-    type: 'roundtrip'
-
+    type: "roundtrip"
 ```
 
-As seen above, mdox supports passing an array of link validators with types and regexes. There are three types of validators,
+As seen above, mdox supports validate configuration supports a few parameters and passing an array of link validators with types and regexes. The supported configuration parameters are:
+
+* `timeout`: The HTTP client's timeout.
+* `parallelism`: The maximum amount of concurrent HTTP requests.
+* `host_max_conns`: The maximum amount of HTTP connections open per host.
+* `random_delay`: A random delay between 0 and this value is added between requests. It takes values like "500ms", "1s", "1m", or "1m30s".
+
+There are three types of validators:
 
 * `ignore`: This type of validator makes sure that `mdox` does not check links with provided regex. This is the most common use case.
 * `githubPullsIssues`: This is a smart validator which only accepts a specific type of regex of the form `(^http[s]?:\/\/)(www\.)?(github\.com\/){ORG}\/{REPO}(\/pull\/|\/issues\/)`. It performs smart validation on GitHub PR and issues links, by fetching GitHub API to get the latest pull/issue number and matching regex. This makes sure that mdox doesn't get rate limited by GitHub, even when checking a large number of GitHub links(which is pretty common in documentation)!

--- a/examples/.mdox.validate.yaml
+++ b/examples/.mdox.validate.yaml
@@ -1,12 +1,15 @@
 version: 1
+timeout: "1m"
+parallelism: 100
+host_max_conns: 2
+random_delay: "1s"
 
 validators:
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
-    type: 'githubPullsIssues'
+    type: "githubPullsIssues"
 
-  - regex: 'localhost'
-    type: 'ignore'
+  - regex: "localhost"
+    type: "ignore"
 
   - regex: 'thanos\.io'
-    type: 'roundtrip'
-
+    type: "roundtrip"

--- a/examples/.mdox.validate.yaml
+++ b/examples/.mdox.validate.yaml
@@ -1,15 +1,15 @@
 version: 1
-timeout: "1m"
+timeout: '1m'
 parallelism: 100
 host_max_conns: 2
-random_delay: "1s"
+random_delay: '1s'
 
 validators:
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)bwplotka\/mdox(\/pull\/|\/issues\/)'
-    type: "githubPullsIssues"
+    type: 'githubPullsIssues'
 
-  - regex: "localhost"
-    type: "ignore"
+  - regex: 'localhost'
+    type: 'ignore'
 
   - regex: 'thanos\.io'
-    type: "roundtrip"
+    type: 'roundtrip'

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -98,7 +98,7 @@ func ParseConfig(c []byte) (Config, error) {
 		}
 	}
 
-	if cfg.Parallelism <= 0 {
+	if cfg.Parallelism < 0 {
 		return Config{}, errors.New("parsing parallelism, has to be > 0")
 	}
 

--- a/pkg/mdformatter/linktransformer/config.go
+++ b/pkg/mdformatter/linktransformer/config.go
@@ -20,10 +20,16 @@ import (
 type Config struct {
 	Version int
 
-	Validators []ValidatorConfig `yaml:"validators"`
-	Timeout    string            `yaml:"timeout"`
+	Validators  []ValidatorConfig `yaml:"validators"`
+	Timeout     string            `yaml:"timeout"`
+	Parallelism int               `yaml:"parallelism"`
+	// HostMaxConns has to be a pointer because a zero value means no limits
+	// and we have to tell apart 0 from not-present configurations.
+	HostMaxConns *int   `yaml:"host_max_conns"`
+	RandomDelay  string `yaml:"random_delay"`
 
-	timeout time.Duration
+	timeout     time.Duration
+	randomDelay time.Duration
 }
 
 type ValidatorConfig struct {
@@ -82,6 +88,18 @@ func ParseConfig(c []byte) (Config, error) {
 		if err != nil {
 			return Config{}, errors.Wrap(err, "parsing timeout duration")
 		}
+	}
+
+	if cfg.RandomDelay != "" {
+		var err error
+		cfg.randomDelay, err = time.ParseDuration(cfg.RandomDelay)
+		if err != nil {
+			return Config{}, errors.Wrap(err, "parsing random delay duration")
+		}
+	}
+
+	if cfg.Parallelism <= 0 {
+		return Config{}, errors.New("parsing parallelism, has to be > 0")
 	}
 
 	if len(cfg.Validators) <= 0 {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -208,10 +208,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 	}
 
 	linktransformerMetrics := newLinktransformerMetrics(reg)
-	collector := colly.NewCollector(colly.Async(), colly.StdlibContext(ctx), colly.MaxDepth(1))
-	collector.SetClient(&http.Client{
-		Timeout: 30 * time.Second,
-	})
+	collector := colly.NewCollector(colly.Async(), colly.StdlibContext(ctx))
 	transport := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		ForceAttemptHTTP2:     true,

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -257,7 +257,8 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 	}
 
 	limitRule := &colly.LimitRule{
-		DomainGlob: "*",
+		DomainGlob:  "*",
+		Parallelism: 100,
 	}
 	if config.Parallelism != 0 {
 		limitRule.Parallelism = config.Parallelism

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -223,7 +223,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		}).DialContext,
 	}
 	if config.HostMaxConns != nil {
-		transport.MaxIdleConnsPerHost = *config.HostMaxConns
+		transport.MaxConnsPerHost = *config.HostMaxConns
 	}
 	v := &validator{
 		logger:         logger,

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -260,7 +260,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		DomainGlob:  "*",
 		Parallelism: 100,
 	}
-	if config.Parallelism != 0 {
+	if config.Parallelism > 0 {
 		limitRule.Parallelism = config.Parallelism
 	}
 	if config.RandomDelay != "" {

--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -220,10 +220,10 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 	}
 	v := &validator{
 		logger:         logger,


### PR DESCRIPTION
Related to #22. 

- Stop relying on the `http.DefaultHTTPTransport`: it's effectively global state. It can be 
  modified by any other package. It has different default configuration depending on the 
  Go compiler version and we cannot trust that these defaults are good for us.

- Considering this is a tool often ran in resource constrained
  environments, like Github Actions, the HTTP client timeout was bumped
  to 30 seconds.

- Colly was configured with a depth of 1, to avoid crawling too much
  information from the websites

- The parallelism configuration of `colly` has been brought down from 100
  to 10. This setting means that at most 10 requests will be sent in
  parallel for the matching domains, instead of 100. This way we are 
  more friendly to the servers and hopefully they will be happier with us too, 
  returning more responses with 200 status code faster.

- Added a random delay of up to 1 second to create new requests to
  matching domains, again to be more friendly with the servers, etc,  etc.

## How did I test this?

I compiled a binary and ran the `make check-docs` target of the https://github.com/thanos-io/thanos project a couple of times without my changes and with them.

Without the changes it's easy to reproduce the failures indicated by #22. 

With the changes, I couldn't reproduce them.  

## How does it affect run time?

Locals runs were taking:

* Without changes: Failed local runs that failed were taking 2m48s. Successful local runs could be as fast as 1m31s.
* With changes
  * With 1s random delay: 3m20s.
  * Without random delay: 1m30s.

There are a lot of variables involved though, it isn't a reliable measurement. 

I think I could be able to get rid of the random delay to make this faster while still avoiding the intermittent failures, if that's desirable. WDYT, @bwplotka? 