### PR TITLE
Parse cache settings manually for friendly errors

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -265,7 +265,7 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 
 	if v.validateConfig.Cache.Type != none && storage != nil {
 		v.storage = storage
-		if err = v.storage.Init(v.validateConfig.Cache.Validity, v.validateConfig.Cache.Jitter); err != nil {
+		if err = v.storage.Init(v.validateConfig.Cache.validity, v.validateConfig.Cache.jitter); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Just like it's done for all the other configuration options that
are based off of time durations.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com