### PR TITLE
Drop ioutil

### DIFF
--- a/pkg/mdformatter/linktransformer/link_bench_test.go
+++ b/pkg/mdformatter/linktransformer/link_bench_test.go
@@ -6,7 +6,6 @@ package linktransformer
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,13 +34,13 @@ This is a test section [link](./doc.md#this-is-a-section)`
 )
 
 func benchLinktransformer(b *testing.B) {
-	tmpDir, err := ioutil.TempDir("", "bench-test")
+	tmpDir, err := os.MkdirTemp("", "bench-test")
 	testutil.Ok(b, err)
 	b.Cleanup(func() { testutil.Ok(b, os.RemoveAll(tmpDir)) })
 
 	testutil.Ok(b, os.MkdirAll(filepath.Join(tmpDir, "repo", "docs"), os.ModePerm))
-	testutil.Ok(b, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc.md"), []byte(testDoc), os.ModePerm))
-	testutil.Ok(b, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "links.md"), []byte(testDocWithLink), os.ModePerm))
+	testutil.Ok(b, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc.md"), []byte(testDoc), os.ModePerm))
+	testutil.Ok(b, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "links.md"), []byte(testDocWithLink), os.ModePerm))
 	anchorDir := filepath.Join(tmpDir, "repo", "docs")
 	logger := log.NewLogfmtLogger(os.Stderr)
 

--- a/pkg/mdformatter/linktransformer/link_test.go
+++ b/pkg/mdformatter/linktransformer/link_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -40,13 +39,13 @@ const (
 )
 
 func TestLocalizer_TransformDestination(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-localizer")
+	tmpDir, err := os.MkdirTemp("", "test-localizer")
 	testutil.Ok(t, err)
 	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
 
 	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "repo", "docs", "a"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "a", "doc.md"), []byte(testDocWithLinks), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc2.md"), []byte(testDocWithLinks), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "a", "doc.md"), []byte(testDocWithLinks), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc2.md"), []byte(testDocWithLinks), os.ModePerm))
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	anchorDir := filepath.Join(tmpDir, "repo", "docs")
@@ -123,20 +122,20 @@ func TestLocalizer_TransformDestination(t *testing.T) {
 }
 
 func TestValidator_TransformDestination(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-validator")
+	tmpDir, err := os.MkdirTemp("", "test-validator")
 	testutil.Ok(t, err)
 	t.Cleanup(func() { testutil.Ok(t, os.RemoveAll(tmpDir)) })
 
 	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "repo", "docs", "a"), os.ModePerm))
 	testutil.Ok(t, os.MkdirAll(filepath.Join(tmpDir, "repo", "docs", "test"), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "a", "doc.md"), []byte(testDocWithLinks), os.ModePerm))
-	testutil.Ok(t, ioutil.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc2.md"), []byte(testDocWithLinks), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "a", "doc.md"), []byte(testDocWithLinks), os.ModePerm))
+	testutil.Ok(t, os.WriteFile(filepath.Join(tmpDir, "repo", "docs", "doc2.md"), []byte(testDocWithLinks), os.ModePerm))
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	anchorDir := filepath.Join(tmpDir, "repo", "docs")
 	t.Run("check valid link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
 		testutil.Ok(t, err)
@@ -152,8 +151,8 @@ func TestValidator_TransformDestination(t *testing.T) {
 	t.Run("check valid but same link in diff files", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
 		testFile2 := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link2.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
-		testutil.Ok(t, ioutil.WriteFile(testFile2, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile2, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile, testFile2})
 		testutil.Ok(t, err)
@@ -168,7 +167,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid local links", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# yolo
+		testutil.Ok(t, os.WriteFile(testFile, []byte(`# yolo
 
 [1](.) [2](#yolo) [3](../test/valid-local-links.md) [4](../test/valid-local-links.md#yolo) [5](../a/doc.md)
 `), os.ModePerm))
@@ -186,7 +185,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid local links with dash", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links-with-dash.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# Expose UI on a sub-path
+		testutil.Ok(t, os.WriteFile(testFile, []byte(`# Expose UI on a sub-path
 
 [1](#expose-ui-on-a-sub-path)
 
@@ -208,7 +207,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid local links in diff language", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-local-links-diff-lang.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# Twój wkład w dokumentację
+		testutil.Ok(t, os.WriteFile(testFile, []byte(`# Twój wkład w dokumentację
 
 [1](#twój-wkład-w-dokumentację)
 
@@ -235,7 +234,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 		testutil.Ok(t, err)
 		relDirPath, err := filepath.Rel(wdir, tmpDir)
 		testutil.Ok(t, err)
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# yolo
+		testutil.Ok(t, os.WriteFile(testFile, []byte(`# yolo
 
 [1](.) [2](#not-yolo) [3](../test2/invalid-local-links.md) [4](../test/invalid-local-links.md#not-yolo) [5](../test/doc.md)
 `), os.ModePerm))
@@ -259,7 +258,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid email link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-email.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("[yolo](mailto:test@yahoo.com)\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("[yolo](mailto:test@yahoo.com)\n"), os.ModePerm))
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
 		testutil.Ok(t, err)
@@ -274,7 +273,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check invalid email link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-email.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("[yolo](mailto:test@mdox.com)\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("[yolo](mailto:test@mdox.com)\n"), os.ModePerm))
 		filePath := "/repo/docs/test/invalid-email.md"
 		wdir, err := os.Getwd()
 		testutil.Ok(t, err)
@@ -294,7 +293,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check 404 link", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists https://docs.gfoogle.com/drawings/d/e/2PACX-1vTBFK_cGMbxFpYcv/pub?w=960&h=720\n"), os.ModePerm))
 		filePath := "/repo/docs/test/invalid-link.md"
 		wdir, err := os.Getwd()
 		testutil.Ok(t, err)
@@ -316,7 +315,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid & 404 link with validate config", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-link2.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://www.github.com/ https://bwplotka.dev/does-not-exits\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://www.github.com/ https://bwplotka.dev/does-not-exits\n"), os.ModePerm))
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
 		testutil.Ok(t, err)
@@ -330,7 +329,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check 404 links with ignore validate config", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "links.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://fakelink1.com/ http://fakelink2.com/ https://www.fakelink3.com/\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://fakelink1.com/ http://fakelink2.com/ https://www.fakelink3.com/\n"), os.ModePerm))
 
 		diff, err := mdformatter.IsFormatted(context.TODO(), logger, []string{testFile})
 		testutil.Ok(t, err)
@@ -344,7 +343,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check github links with validate config", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "github-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://github.com/bwplotka/mdox/issues/23 https://github.com/bwplotka/mdox/pull/32 https://github.com/bwplotka/mdox/pull/27#pullrequestreview-659598194\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://github.com/bwplotka/mdox/issues/23 https://github.com/bwplotka/mdox/pull/32 https://github.com/bwplotka/mdox/pull/27#pullrequestreview-659598194\n"), os.ModePerm))
 		// This is substituted in config using PathorContent flag. But need to pass it directly here.
 		repoToken := os.Getenv("GITHUB_TOKEN")
 
@@ -360,7 +359,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check invalid local links with ignore validate config", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-local-links.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte(`# yolo
+		testutil.Ok(t, os.WriteFile(testFile, []byte(`# yolo
 
 [1](.) [2](#yolo) [3](../test/invalid-local-links.md#wrong) [4](../test/invalid-local-links.md#not-yolo)
 `), os.ModePerm))
@@ -380,7 +379,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 	t.Run("check valid link with cache", func(t *testing.T) {
 		var id int
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
 		testStorage := &cache.SQLite3Storage{
 			Filename: filepath.Join(tmpDir, "repo", "docs", "test", "mdoxcachetest"),
@@ -415,7 +414,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check valid link with no cache", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "valid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/about\n"), os.ModePerm))
 
 		testStorage := &cache.SQLite3Storage{
 			Filename: filepath.Join(tmpDir, "repo", "docs", "test", "mdoxcachetest2"),
@@ -435,7 +434,7 @@ func TestValidator_TransformDestination(t *testing.T) {
 
 	t.Run("check 404 link with cache", func(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "repo", "docs", "test", "invalid-link.md")
-		testutil.Ok(t, ioutil.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists\n"), os.ModePerm))
+		testutil.Ok(t, os.WriteFile(testFile, []byte("https://bwplotka.dev/does-not-exists\n"), os.ModePerm))
 		filePath := "/repo/docs/test/invalid-link.md"
 		wdir, err := os.Getwd()
 		testutil.Ok(t, err)

--- a/pkg/mdformatter/mdformatter.go
+++ b/pkg/mdformatter/mdformatter.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -317,7 +316,7 @@ func format(ctx context.Context, logger log.Logger, files []string, diffs *Diffs
 					return err
 				}
 
-				in, err := ioutil.ReadAll(file)
+				in, err := io.ReadAll(file)
 				if err != nil {
 					return errors.Wrapf(err, "read all %v", fn)
 				}
@@ -351,7 +350,7 @@ func (f *Formatter) Format(file *os.File, out io.Writer) error {
 		Filepath: file.Name(),
 	}
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		return errors.Wrapf(err, "read %v", file.Name())
 	}

--- a/pkg/mdformatter/mdformatter_test.go
+++ b/pkg/mdformatter/mdformatter_test.go
@@ -6,7 +6,6 @@ package mdformatter
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestFormat_FormatSingle_NoTransformers(t *testing.T) {
 
 	f := New(context.Background())
 
-	exp, err := ioutil.ReadFile("testdata/formatted.md")
+	exp, err := os.ReadFile("testdata/formatted.md")
 	testutil.Ok(t, err)
 
 	t.Run("Format not formatted", func(t *testing.T) {
@@ -50,7 +49,7 @@ func TestCheck_NoTransformers(t *testing.T) {
 	diff, err = IsFormatted(context.Background(), log.NewNopLogger(), []string{"testdata/not_formatted.md"})
 	testutil.Ok(t, err)
 
-	exp, err := ioutil.ReadFile("testdata/not_formatted.md.diff")
+	exp, err := os.ReadFile("testdata/not_formatted.md.diff")
 	testutil.Ok(t, err)
 	testutil.Equals(t, string(exp), diff.String())
 }
@@ -85,7 +84,7 @@ func TestFormat_FormatSingle_Transformers(t *testing.T) {
 	f := New(context.Background())
 	f.link = m
 
-	exp, err := ioutil.ReadFile("testdata/formatted_and_transformed.md")
+	exp, err := os.ReadFile("testdata/formatted_and_transformed.md")
 	testutil.Ok(t, err)
 
 	t.Run("Format not formatted", func(t *testing.T) {
@@ -115,7 +114,7 @@ func TestFormat_FormatSingle_SoftWraps(t *testing.T) {
 
 	f := New(context.Background(), WithSoftWraps())
 
-	exp, err := ioutil.ReadFile("testdata/formatted_softwraps.md")
+	exp, err := os.ReadFile("testdata/formatted_softwraps.md")
 	testutil.Ok(t, err)
 
 	t.Run("Format not formatted", func(t *testing.T) {
@@ -144,7 +143,7 @@ func TestCheck_SoftWraps(t *testing.T) {
 	diff, err = IsFormatted(context.Background(), log.NewNopLogger(), []string{"testdata/not_formatted_softwraps.md"}, WithSoftWraps())
 	testutil.Ok(t, err)
 
-	exp, err := ioutil.ReadFile("testdata/not_formatted_softwraps.md.diff")
+	exp, err := os.ReadFile("testdata/not_formatted_softwraps.md.diff")
 	testutil.Ok(t, err)
 	testutil.Equals(t, string(exp), diff.String())
 }

--- a/pkg/mdformatter/mdgen/mdgen_test.go
+++ b/pkg/mdformatter/mdgen/mdgen_test.go
@@ -6,7 +6,6 @@ package mdgen
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 func TestFormat_FormatSingle_CodeBlockTransformer(t *testing.T) {
 	f := mdformatter.New(context.Background(), mdformatter.WithCodeBlockTransformer(NewCodeBlockTransformer()))
 
-	exp, err := ioutil.ReadFile("testdata/mdgen_formatted.md")
+	exp, err := os.ReadFile("testdata/mdgen_formatted.md")
 	testutil.Ok(t, err)
 
 	t.Run("Format not formatted", func(t *testing.T) {

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,7 +49,7 @@ func prepOutputDir(d string, gitIgnored bool) error {
 	}
 
 	if gitIgnored {
-		if err = ioutil.WriteFile(filepath.Join(d, ".gitignore"), []byte("*"), os.ModePerm); err != nil {
+		if err = os.WriteFile(filepath.Join(d, ".gitignore"), []byte("*"), os.ModePerm); err != nil {
 			return err
 		}
 	}
@@ -199,7 +198,7 @@ func (t *transformer) transformFile(path string, info os.FileInfo, err error) er
 		}
 
 		if rest != nil {
-			if err := ioutil.WriteFile(target, rest, os.ModePerm); err != nil {
+			if err := os.WriteFile(target, rest, os.ModePerm); err != nil {
 				return err
 			}
 		}
@@ -503,7 +502,7 @@ func getFirstHeader(path string, popHeader bool) (_ string, rest []byte, err err
 			if _, err := file.Seek(int64(len(text)), 0); err != nil {
 				return "", nil, errors.Wrap(err, "seek")
 			}
-			rest, err := ioutil.ReadAll(file)
+			rest, err := io.ReadAll(file)
 			if err != nil {
 				return "", nil, errors.Wrap(err, "read")
 			}

--- a/pkg/transform/transform_e2e_test.go
+++ b/pkg/transform/transform_e2e_test.go
@@ -6,7 +6,6 @@ package transform_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,20 +27,20 @@ func TestTransform(t *testing.T) {
 
 	testutil.Ok(t, os.RemoveAll(tmpDir))
 	t.Run("mdox1.yaml", func(t *testing.T) {
-		mdox1, err := ioutil.ReadFile(filepath.Join(testData, "mdox1.yaml"))
+		mdox1, err := os.ReadFile(filepath.Join(testData, "mdox1.yaml"))
 		testutil.Ok(t, err)
 		testutil.Ok(t, transform.Dir(context.Background(), logger, mdox1))
 		assertDirContent(t, filepath.Join(testData, "expected", "test1"), filepath.Join(tmpDir, "test1"))
 	})
 	t.Run("mdox2.yaml", func(t *testing.T) {
-		mdox2, err := ioutil.ReadFile(filepath.Join(testData, "mdox2.yaml"))
+		mdox2, err := os.ReadFile(filepath.Join(testData, "mdox2.yaml"))
 		testutil.Ok(t, err)
 		testutil.Ok(t, transform.Dir(context.Background(), logger, mdox2))
 		assertDirContent(t, filepath.Join(testData, "expected", "test2"), filepath.Join(tmpDir, "test2"))
 
 	})
 	t.Run("mdox3.yaml", func(t *testing.T) {
-		mdox2, err := ioutil.ReadFile(filepath.Join(testData, "mdox3.yaml"))
+		mdox2, err := os.ReadFile(filepath.Join(testData, "mdox3.yaml"))
 		testutil.Ok(t, err)
 		testutil.Ok(t, transform.Dir(context.Background(), logger, mdox2))
 		assertDirContent(t, filepath.Join(testData, "expected", "test3"), filepath.Join(tmpDir, "test3"))
@@ -81,11 +80,11 @@ func assertDirContent(t *testing.T, expectedDir string, gotDir string) {
 			return errors.Errorf("%v is a dir, but not expected a dir, but file", e)
 		}
 
-		expectedContent, err := ioutil.ReadFile(path)
+		expectedContent, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		content, err := ioutil.ReadFile(expectedPath)
+		content, err := os.ReadFile(expectedPath)
 		if err != nil {
 			return err
 		}

--- a/scripts/copyright/copyright.go
+++ b/scripts/copyright/copyright.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -42,7 +41,7 @@ func applyLicenseToProtoAndGo() error {
 			return nil
 		}
 
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -53,7 +52,7 @@ func applyLicenseToProtoAndGo() error {
 			var bb bytes.Buffer
 			_, _ = bb.Write(license)
 			_, _ = bb.Write(b)
-			if err = ioutil.WriteFile(path, bb.Bytes(), 0666); err != nil {
+			if err = os.WriteFile(path, bb.Bytes(), 0666); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
ioutil was deprecated in Go 1.16.
Drop all usage of ioutil in favor of non-ioutil variants.
