### PR TITLE
Upgrade markdownfmt, add opt-out for gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Flags:
                                  instead it will fail if files needs formatting
       --soft-wraps               If true, fmt will preserve soft line breaks for
                                  given files
+      --no-code-fmt              If true, don't reformat code snippets
       --code.disable-directives  If false, fmt will parse custom fenced
                                  code directives prefixed with 'mdox-gen' to
                                  autogenerate code snippets. For example:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bwplotka/mdox
 go 1.19
 
 require (
-	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4
+	github.com/Kunde21/markdownfmt/v3 v3.0.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/efficientgo/tools/core v0.0.0-20210609125236-d73259166f20
 	github.com/efficientgo/tools/extkingpin v0.0.0-20210609125236-d73259166f20

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bwplotka/mdox
 go 1.19
 
 require (
-	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c
+	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/efficientgo/tools/core v0.0.0-20210609125236-d73259166f20
 	github.com/efficientgo/tools/extkingpin v0.0.0-20210609125236-d73259166f20

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c h1:rnouiLtDKeaWKnxRViK454oCI8jkhWv5fItCvZ9nJOU=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20210810103848-727f02f4c51c/go.mod h1:LFJueuHZej/Z7Xhqh/XgClfkDjZiiEBOLVTt1Duq1r0=
+github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4 h1:ANaegQpChGSuQKdin4sBcMMKj5ioBpFe1NAhw3UbLFI=
+github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4/go.mod h1:X/nFiloNLnUOttUXJm0Jt9f8Hj7ElLmUHrMsQoEo5zg=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -223,7 +223,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -496,7 +496,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.4/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yuin/goldmark v1.4.12 h1:6hffw6vALvEDqJ19dOJvJKOoAOKe4NDaTqvd2sktGN0=
 github.com/yuin/goldmark v1.4.12/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4 h1:ANaegQpChGSuQKdin4sBcMMKj5ioBpFe1NAhw3UbLFI=
-github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4/go.mod h1:X/nFiloNLnUOttUXJm0Jt9f8Hj7ElLmUHrMsQoEo5zg=
+github.com/Kunde21/markdownfmt/v3 v3.0.0 h1:iRzqcuRSHTlZ4QPNAGgoJtfcwTDlPlupx+8OAFJpUx4=
+github.com/Kunde21/markdownfmt/v3 v3.0.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -223,7 +223,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -478,8 +478,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/tdewolff/parse/v2 v2.6.0 h1:f2D7w32JtqjCv6SczWkfwK+m15et42qEtDnZXHoNY70=
 github.com/tdewolff/parse/v2 v2.6.0/go.mod h1:WzaJpRSbwq++EIQHYIRTpbYKNA3gn9it1Ik++q4zyho=
 github.com/tdewolff/test v1.0.6 h1:76mzYJQ83Op284kMT+63iCNCI7NEERsIN8dLM+RiKr4=

--- a/main.go
+++ b/main.go
@@ -124,7 +124,6 @@ func main() {
 		level.Error(logger).Log("err", errors.Wrapf(err, "%s command failed", cmd))
 		os.Exit(1)
 	}
-
 }
 
 func snapshotProfiles(dir string) (func() error, error) {
@@ -203,6 +202,7 @@ func registerFmt(_ context.Context, app *extkingpin.App, metricsPath *string) {
 	files := cmd.Arg("files", "Markdown file(s) to process.").Required().ExistingFiles()
 	checkOnly := cmd.Flag("check", "If true, fmt will not modify the given files, instead it will fail if files needs formatting").Bool()
 	softWraps := cmd.Flag("soft-wraps", "If true, fmt will preserve soft line breaks for given files").Bool()
+	noCodeFmt := cmd.Flag("no-code-fmt", "If true, don't reformat code snippets").Bool()
 
 	disableGenCodeBlocksDirectives := cmd.Flag("code.disable-directives", `If false, fmt will parse custom fenced code directives prefixed with 'mdox-gen' to autogenerate code snippets. For example:
 	`+"```"+`<lang> mdox-exec="<executable + arguments>"
@@ -227,6 +227,9 @@ This directive runs executable with arguments and put its stderr and stdout outp
 		}
 		if *softWraps {
 			opts = append(opts, mdformatter.WithSoftWraps())
+		}
+		if *noCodeFmt {
+			opts = append(opts, mdformatter.WithNoCodeFmt())
 		}
 		if len(*files) == 0 {
 			return errors.New("no files to format")

--- a/pkg/mdformatter/mdformatter.go
+++ b/pkg/mdformatter/mdformatter.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/Kunde21/markdownfmt/v2/markdown"
+	"github.com/Kunde21/markdownfmt/v3/markdown"
 	"github.com/bwplotka/mdox/pkg/gitdiff"
 	"github.com/efficientgo/tools/core/pkg/logerrcapture"
 	"github.com/efficientgo/tools/core/pkg/merrors"

--- a/pkg/mdformatter/mdformatter.go
+++ b/pkg/mdformatter/mdformatter.go
@@ -83,9 +83,10 @@ type Formatter struct {
 	bm   BackMatterTransformer
 	link LinkTransformer
 	cb   CodeBlockTransformer
+	reg  *prometheus.Registry
 
-	reg       *prometheus.Registry
 	softWraps bool
+	noCodeFmt bool
 }
 
 // Option is a functional option type for Formatter objects.
@@ -130,6 +131,13 @@ func WithMetrics(reg *prometheus.Registry) Option {
 func WithSoftWraps() Option {
 	return func(m *Formatter) {
 		m.softWraps = true
+	}
+}
+
+// WithNoCodeFmt specifies that we shouldn't reformat code snippets.
+func WithNoCodeFmt() Option {
+	return func(m *Formatter) {
+		m.noCodeFmt = true
 	}
 }
 
@@ -395,7 +403,10 @@ func (f *Formatter) Format(file *os.File, out io.Writer) error {
 	if f.softWraps {
 		renderer.AddMarkdownOptions(markdown.WithSoftWraps())
 	}
-	renderer.AddMarkdownOptions(markdown.WithCodeFormatters(markdown.GoCodeFormatter))
+	// Enable Go code reformatting unless --no-code-fmt is set.
+	if !f.noCodeFmt {
+		renderer.AddMarkdownOptions(markdown.WithCodeFormatters(markdown.GoCodeFormatter))
+	}
 	tr := &transformer{
 		wrapped:   renderer,
 		sourceCtx: sourceCtx,

--- a/pkg/mdformatter/mdformatter.go
+++ b/pkg/mdformatter/mdformatter.go
@@ -395,6 +395,7 @@ func (f *Formatter) Format(file *os.File, out io.Writer) error {
 	if f.softWraps {
 		renderer.AddMarkdownOptions(markdown.WithSoftWraps())
 	}
+	renderer.AddMarkdownOptions(markdown.WithCodeFormatters(markdown.GoCodeFormatter))
 	tr := &transformer{
 		wrapped:   renderer,
 		sourceCtx: sourceCtx,

--- a/pkg/mdformatter/mdformatter_test.go
+++ b/pkg/mdformatter/mdformatter_test.go
@@ -147,3 +147,35 @@ func TestCheck_SoftWraps(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Equals(t, string(exp), diff.String())
 }
+
+func TestFormatBadlyFormattedGoCode(t *testing.T) {
+	t.Run("Format WithNoCodeFmt", func(t *testing.T) {
+		file, err := os.OpenFile("testdata/badly_formatted_go_code.md", os.O_RDONLY, 0)
+		testutil.Ok(t, err)
+		defer file.Close()
+
+		f := New(context.Background(), WithNoCodeFmt())
+
+		exp, err := os.ReadFile("testdata/badly_formatted_go_code.md")
+		testutil.Ok(t, err)
+
+		buf := bytes.Buffer{}
+		testutil.Ok(t, f.Format(file, &buf))
+		testutil.Equals(t, string(exp), buf.String())
+	})
+
+	t.Run("Format", func(t *testing.T) {
+		file, err := os.OpenFile("testdata/badly_formatted_go_code.md", os.O_RDONLY, 0)
+		testutil.Ok(t, err)
+		defer file.Close()
+
+		f := New(context.Background())
+
+		exp, err := os.ReadFile("testdata/badly_formatted_go_code.reformatted.md")
+		testutil.Ok(t, err)
+
+		buf := bytes.Buffer{}
+		testutil.Ok(t, f.Format(file, &buf))
+		testutil.Equals(t, string(exp), buf.String())
+	})
+}

--- a/pkg/mdformatter/testdata/badly_formatted_go_code.md
+++ b/pkg/mdformatter/testdata/badly_formatted_go_code.md
@@ -1,0 +1,17 @@
+This file contains a poorly formatted Go source file.
+
+```go
+package main
+
+import "net/http"
+
+func main() {
+  // Using two spaces for indentation.
+  fmt.Println(
+    "intentionally",
+      "poorly",
+        "formatted",)
+}
+```
+
+Next paragraph.

--- a/pkg/mdformatter/testdata/badly_formatted_go_code.reformatted.md
+++ b/pkg/mdformatter/testdata/badly_formatted_go_code.reformatted.md
@@ -1,0 +1,17 @@
+This file contains a poorly formatted Go source file.
+
+```go
+package main
+
+import "net/http"
+
+func main() {
+	// Using two spaces for indentation.
+	fmt.Println(
+		"intentionally",
+		"poorly",
+		"formatted")
+}
+```
+
+Next paragraph.


### PR DESCRIPTION
markdownfmt v3 was recently released,
and among the changes is how Go source blocks are handled.
They're no longer automatically run through gofmt.
Instead, users may opt-into this functionality with the following option:

    markdown.WithCodeFormatters(markdown.GoCodeFormatter)

Since mdox prefers to have Go blocks auto-formatted,
this PR enables that by default,
and adds an opt-out flag (`--no-code-fmt`)
for users who don't want that functionality.

Supersedes #98
