### PR TITLE
mdox-exec: Also add newline when non-zero exit code

### DIFF
--- a/pkg/mdformatter/mdgen/mdgen.go
+++ b/pkg/mdformatter/mdgen/mdgen.go
@@ -83,10 +83,13 @@ func (t *genCodeBlockTransformer) TransformCodeBlock(ctx mdformatter.SourceConte
 		cmd.Stdout = &b
 		if err := cmd.Run(); err != nil {
 			expectedCode, _ := strconv.Atoi(infoStringAttr[infoStringKeyExitCode])
-			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == expectedCode {
-				return b.Bytes(), nil
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if exitErr.ExitCode() != expectedCode {
+					return nil, errors.Wrapf(err, "run %v, expected exit code %v, got %v, out: %v", execCmd, expectedCode, exitErr.ExitCode(), b.String())
+				}
+			} else {
+				return nil, errors.Wrapf(err, "run %v, out: %v", execCmd, b.String())
 			}
-			return nil, errors.Wrapf(err, "run %v, out: %v", execCmd, b.String())
 		}
 		output := b.Bytes()
 		// Add newline to output if not present.

--- a/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
+++ b/pkg/mdformatter/mdgen/testdata/mdgen_formatted.md
@@ -34,7 +34,7 @@ test output3
 ```bash mdox-exec="sed -n '1,3p' ./testdata/out3.sh"
 #!/usr/bin/env bash
 
-echo "test output3"
+echo -n "test output3"
 ```
 
 ```yaml mdox-exec="bash ./testdata/out2.sh --name=queryfrontend.InMemoryResponseCacheConfig"
@@ -45,6 +45,6 @@ newline
 ```bash mdox-exec="cat ./testdata/out3.sh"
 #!/usr/bin/env bash
 
-echo "test output3"
+echo -n "test output3"
 exit 2
 ```

--- a/pkg/mdformatter/mdgen/testdata/out3.sh
+++ b/pkg/mdformatter/mdgen/testdata/out3.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-echo "test output3"
+echo -n "test output3"
 exit 2


### PR DESCRIPTION
A new line (`\n`) is added at the end of `mdox-exec` output, but only when the exit code is 0 (not when using a non-zero `mdox-expect-exit-code`):

https://github.com/bwplotka/mdox/blob/53a5104b2ef519f3e35ebb0605c86121c503bc38/pkg/mdformatter/mdgen/mdgen.go#L92-L95

The new line should always be added (if not present).

Tests are updated to use `echo -n` (prints no `\n`).