### PR TITLE
Fix: `http2: timeout awaiting response headers` error

### DIFF
--- a/pkg/mdformatter/linktransformer/link.go
+++ b/pkg/mdformatter/linktransformer/link.go
@@ -222,10 +222,10 @@ func NewValidator(ctx context.Context, logger log.Logger, linksValidateConfig []
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
 		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
+			Timeout:   100 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 	}


### PR DESCRIPTION
ref: https://github.com/prometheus-operator/prometheus-operator/actions/runs/14873742118/job/41767041202?pr=7501

```
error: 2 errors:
		Documentation/proposals/202305-scrapeclasses.md:194: "https://istio.io/latest/docs/reference/config/security/authorization-policy/" not accessible even after retry; status code 0: Get "https://istio.io/latest/docs/reference/config/security/authorization-policy/": http2: timeout awaiting response headers
		Documentation/proposals/202305-scrapeclasses.md:189: "https://istio.io/latest/docs/concepts/security/#permissive-mode" not accessible even after retry; status code 0: Get "https://istio.io/latest/docs/concepts/security/#permissive-mode": http2: timeout awaiting response headers
make: *** [Makefile:341: check-docs] Error 1
```